### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/166/923/421166923.geojson
+++ b/data/421/166/923/421166923.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008707,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"509f483d334a6514924eb505da0bdda1",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421166923,
-    "wof:lastmodified":1566673426,
+    "wof:lastmodified":1582319479,
     "wof:name":"Parita",
     "wof:parent_id":85675781,
     "wof:placetype":"county",

--- a/data/421/168/263/421168263.geojson
+++ b/data/421/168/263/421168263.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008759,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5fe7a1fa28005c598244a6784498b5fd",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421168263,
-    "wof:lastmodified":1566673426,
+    "wof:lastmodified":1582319479,
     "wof:name":"Pacora",
     "wof:parent_id":421196975,
     "wof:placetype":"localadmin",

--- a/data/421/169/151/421169151.geojson
+++ b/data/421/169/151/421169151.geojson
@@ -256,6 +256,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008797,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4b304180e545f1ad5314efa944e1499a",
     "wof:hierarchy":[
         {
@@ -267,7 +270,7 @@
         }
     ],
     "wof:id":421169151,
-    "wof:lastmodified":1566673431,
+    "wof:lastmodified":1582319479,
     "wof:name":"Chiriqui",
     "wof:parent_id":421171339,
     "wof:placetype":"localadmin",

--- a/data/421/169/663/421169663.geojson
+++ b/data/421/169/663/421169663.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008819,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5f48a78d267f7f818988468316e53c68",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":421169663,
-    "wof:lastmodified":1566673431,
+    "wof:lastmodified":1582319479,
     "wof:name":"Ustupo Yantupo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/169/889/421169889.geojson
+++ b/data/421/169/889/421169889.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008828,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8dd0be953b8e187aaa376ab0e3beecfe",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421169889,
-    "wof:lastmodified":1566673431,
+    "wof:lastmodified":1582319479,
     "wof:name":"Gualaca",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/170/139/421170139.geojson
+++ b/data/421/170/139/421170139.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008839,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8409667ba31f0241b6505cd886216d50",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421170139,
-    "wof:lastmodified":1566673456,
+    "wof:lastmodified":1582319482,
     "wof:name":"Changuinola",
     "wof:parent_id":85675805,
     "wof:placetype":"county",

--- a/data/421/170/141/421170141.geojson
+++ b/data/421/170/141/421170141.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008839,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"609ab87be3acf8e23fed53a5fe78a798",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421170141,
-    "wof:lastmodified":1566673457,
+    "wof:lastmodified":1582319482,
     "wof:name":"Chepigana",
     "wof:parent_id":85675795,
     "wof:placetype":"county",

--- a/data/421/170/973/421170973.geojson
+++ b/data/421/170/973/421170973.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008876,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5d3e25e3c9109ff60ec52ab88a0e8351",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":421170973,
-    "wof:lastmodified":1566673457,
+    "wof:lastmodified":1582319482,
     "wof:name":"Chiriqu\u00ed Grande",
     "wof:parent_id":1108693209,
     "wof:placetype":"localadmin",

--- a/data/421/171/219/421171219.geojson
+++ b/data/421/171/219/421171219.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"89efc18a76881e7da1dfed2bc3b82bfc",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421171219,
-    "wof:lastmodified":1566673464,
+    "wof:lastmodified":1582319482,
     "wof:name":"Dolega",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/171/337/421171337.geojson
+++ b/data/421/171/337/421171337.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008890,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"54a25f6bfe693391d104cacca9530532",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421171337,
-    "wof:lastmodified":1566673463,
+    "wof:lastmodified":1582319482,
     "wof:name":"La Chorrera",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/171/339/421171339.geojson
+++ b/data/421/171/339/421171339.geojson
@@ -368,6 +368,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008890,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"594e057acb0e5a438a3fac41d75aad93",
     "wof:hierarchy":[
         {
@@ -378,7 +381,7 @@
         }
     ],
     "wof:id":421171339,
-    "wof:lastmodified":1566673464,
+    "wof:lastmodified":1582319482,
     "wof:name":"David",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/171/341/421171341.geojson
+++ b/data/421/171/341/421171341.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008890,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"adae950984303dc915f0c1318ef4fadc",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421171341,
-    "wof:lastmodified":1566673464,
+    "wof:lastmodified":1582319483,
     "wof:name":"Montijo",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/421/171/349/421171349.geojson
+++ b/data/421/171/349/421171349.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008890,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7181d8a6f40f2c63296a3f583b49fd54",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421171349,
-    "wof:lastmodified":1566673464,
+    "wof:lastmodified":1582319483,
     "wof:name":"Son\u00e1",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/421/171/351/421171351.geojson
+++ b/data/421/171/351/421171351.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008890,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59e5fec9717fed3f2d66a3db95684c69",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421171351,
-    "wof:lastmodified":1566673465,
+    "wof:lastmodified":1582319483,
     "wof:name":"San Carlos",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/171/563/421171563.geojson
+++ b/data/421/171/563/421171563.geojson
@@ -84,6 +84,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008898,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a174818738b495bec0fbfc6ed15597b6",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":421171563,
-    "wof:lastmodified":1566673465,
+    "wof:lastmodified":1582319483,
     "wof:name":"Remedios",
     "wof:parent_id":421176641,
     "wof:placetype":"localadmin",

--- a/data/421/172/507/421172507.geojson
+++ b/data/421/172/507/421172507.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008945,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03370ef42d80804d6b9a7c4570fc32a6",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421172507,
-    "wof:lastmodified":1566673444,
+    "wof:lastmodified":1582319480,
     "wof:name":"Las Tablas",
     "wof:parent_id":85675785,
     "wof:placetype":"county",

--- a/data/421/172/659/421172659.geojson
+++ b/data/421/172/659/421172659.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008950,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90925ec1023e9d6fd3d7918523d777cf",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":421172659,
-    "wof:lastmodified":1566673443,
+    "wof:lastmodified":1582319480,
     "wof:name":"Taboga",
     "wof:parent_id":1108693275,
     "wof:placetype":"localadmin",

--- a/data/421/173/571/421173571.geojson
+++ b/data/421/173/571/421173571.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459008990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cbb8c6ea008e5224d6819ff3d1f5a79b",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421173571,
-    "wof:lastmodified":1566673441,
+    "wof:lastmodified":1582319480,
     "wof:name":"San Francisco",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/421/174/421/421174421.geojson
+++ b/data/421/174/421/421174421.geojson
@@ -218,6 +218,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009032,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3ad030bcee411a6b7aea976bd39902d",
     "wof:hierarchy":[
         {
@@ -229,7 +232,7 @@
         }
     ],
     "wof:id":421174421,
-    "wof:lastmodified":1566673437,
+    "wof:lastmodified":1582319480,
     "wof:name":"Cocle",
     "wof:parent_id":421202589,
     "wof:placetype":"localadmin",

--- a/data/421/174/909/421174909.geojson
+++ b/data/421/174/909/421174909.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009048,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4262ce8098edb4ab6f010a340a54b655",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421174909,
-    "wof:lastmodified":1566673436,
+    "wof:lastmodified":1582319480,
     "wof:name":"San Carlos",
     "wof:parent_id":421171339,
     "wof:placetype":"localadmin",

--- a/data/421/175/369/421175369.geojson
+++ b/data/421/175/369/421175369.geojson
@@ -182,6 +182,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bff923619591ec779f9a2407727858f9",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":421175369,
-    "wof:lastmodified":1566673446,
+    "wof:lastmodified":1582319480,
     "wof:name":"Balboa",
     "wof:parent_id":85675789,
     "wof:placetype":"county",

--- a/data/421/175/373/421175373.geojson
+++ b/data/421/175/373/421175373.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6cc229f306b61c35af1b22bd74cf4a5",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421175373,
-    "wof:lastmodified":1566673447,
+    "wof:lastmodified":1582319481,
     "wof:name":"Boquete",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/175/375/421175375.geojson
+++ b/data/421/175/375/421175375.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5da9ea1608dc309a448b46a9d1ff1d86",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421175375,
-    "wof:lastmodified":1566673447,
+    "wof:lastmodified":1582319481,
     "wof:name":"San Miguelito",
     "wof:parent_id":85675789,
     "wof:placetype":"county",

--- a/data/421/176/107/421176107.geojson
+++ b/data/421/176/107/421176107.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009095,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"537a83f20c459b6cee92c38e089c30ce",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421176107,
-    "wof:lastmodified":1566673462,
+    "wof:lastmodified":1582319482,
     "wof:name":"Chepo",
     "wof:parent_id":85675789,
     "wof:placetype":"county",

--- a/data/421/176/521/421176521.geojson
+++ b/data/421/176/521/421176521.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009111,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e2f076f24f928423c2b40edb0cf444c7",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421176521,
-    "wof:lastmodified":1566673462,
+    "wof:lastmodified":1582319482,
     "wof:name":"Alanje",
     "wof:parent_id":421202705,
     "wof:placetype":"localadmin",

--- a/data/421/176/639/421176639.geojson
+++ b/data/421/176/639/421176639.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009114,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e76e3573f08cfc867b4d5404865345de",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":421176639,
-    "wof:lastmodified":1566673463,
+    "wof:lastmodified":1582319482,
     "wof:name":"Calobre",
     "wof:parent_id":1108693199,
     "wof:placetype":"localadmin",

--- a/data/421/176/641/421176641.geojson
+++ b/data/421/176/641/421176641.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009115,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e322928e687717b4e7b82137354d79b",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421176641,
-    "wof:lastmodified":1566673462,
+    "wof:lastmodified":1582319482,
     "wof:name":"San F\u00e9lix",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/177/727/421177727.geojson
+++ b/data/421/177/727/421177727.geojson
@@ -75,6 +75,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009158,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"497d386fd99cedfecf9aa8ec1f015e80",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":421177727,
-    "wof:lastmodified":1566673458,
+    "wof:lastmodified":1582319482,
     "wof:name":"Dolega",
     "wof:parent_id":421171219,
     "wof:placetype":"localadmin",

--- a/data/421/179/583/421179583.geojson
+++ b/data/421/179/583/421179583.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009226,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9d8d83141c535efd23950e01b5bf5424",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421179583,
-    "wof:lastmodified":1566673461,
+    "wof:lastmodified":1582319482,
     "wof:name":"Las Cumbres",
     "wof:parent_id":421196975,
     "wof:placetype":"localadmin",

--- a/data/421/180/095/421180095.geojson
+++ b/data/421/180/095/421180095.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009244,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4db108bc36973c372c70167158e0acc6",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":421180095,
-    "wof:lastmodified":1566673438,
+    "wof:lastmodified":1582319480,
     "wof:name":"Boqueron",
     "wof:parent_id":1108693193,
     "wof:placetype":"localadmin",

--- a/data/421/180/103/421180103.geojson
+++ b/data/421/180/103/421180103.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009244,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"07800c818a7f9d240bb4b37e1d7c7b15",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":421180103,
-    "wof:lastmodified":1566673437,
+    "wof:lastmodified":1582319480,
     "wof:name":"Los Olivos",
     "wof:parent_id":1108693235,
     "wof:placetype":"localadmin",

--- a/data/421/180/185/421180185.geojson
+++ b/data/421/180/185/421180185.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009247,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"24679b8b7ba85240593dc4837fac4d23",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421180185,
-    "wof:lastmodified":1566673438,
+    "wof:lastmodified":1582319480,
     "wof:name":"Tonosi",
     "wof:parent_id":421203469,
     "wof:placetype":"localadmin",

--- a/data/421/181/403/421181403.geojson
+++ b/data/421/181/403/421181403.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009295,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b276f848bacabaf412ed7ea3bad7ccb6",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421181403,
-    "wof:lastmodified":1566673446,
+    "wof:lastmodified":1582319480,
     "wof:name":"Santa Fe",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/421/181/905/421181905.geojson
+++ b/data/421/181/905/421181905.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009312,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c17e4011ffa443416c66edfd3140bb2",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421181905,
-    "wof:lastmodified":1566673445,
+    "wof:lastmodified":1582319480,
     "wof:name":"Capira",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/183/077/421183077.geojson
+++ b/data/421/183/077/421183077.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009357,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c796ec0d6f455d40f25a658c625321c6",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421183077,
-    "wof:lastmodified":1566673458,
+    "wof:lastmodified":1582319482,
     "wof:name":"Chiguiri Arriba",
     "wof:parent_id":421202589,
     "wof:placetype":"localadmin",

--- a/data/421/184/527/421184527.geojson
+++ b/data/421/184/527/421184527.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009413,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"58276fc3b781b6d8da9ce162d9b7ee97",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":421184527,
-    "wof:lastmodified":1566673455,
+    "wof:lastmodified":1582319482,
     "wof:name":"Las Lomas",
     "wof:parent_id":421171339,
     "wof:placetype":"localadmin",

--- a/data/421/184/905/421184905.geojson
+++ b/data/421/184/905/421184905.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009426,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5543a8b51c99771ea170a070418372b8",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421184905,
-    "wof:lastmodified":1566673455,
+    "wof:lastmodified":1582319482,
     "wof:name":"Besiko",
     "wof:parent_id":85675807,
     "wof:placetype":"county",

--- a/data/421/185/833/421185833.geojson
+++ b/data/421/185/833/421185833.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009456,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1bc9aafb8b04a202e2fee2449c60a8cb",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421185833,
-    "wof:lastmodified":1566673466,
+    "wof:lastmodified":1582319483,
     "wof:name":"Cativa",
     "wof:parent_id":1108693211,
     "wof:placetype":"localadmin",

--- a/data/421/185/837/421185837.geojson
+++ b/data/421/185/837/421185837.geojson
@@ -69,6 +69,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009456,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a054a55d1f44522e5684434323ac2c6",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":421185837,
-    "wof:lastmodified":1566673466,
+    "wof:lastmodified":1582319483,
     "wof:name":"Ca\u00f1azas",
     "wof:parent_id":1108693201,
     "wof:placetype":"localadmin",

--- a/data/421/187/881/421187881.geojson
+++ b/data/421/187/881/421187881.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009527,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"70f9623d153934e939d1731934b93099",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421187881,
-    "wof:lastmodified":1566673438,
+    "wof:lastmodified":1582319480,
     "wof:name":"Anton",
     "wof:parent_id":1108693185,
     "wof:placetype":"localadmin",

--- a/data/421/188/605/421188605.geojson
+++ b/data/421/188/605/421188605.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009571,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3e230661bbb503f3602287087b704e64",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":421188605,
-    "wof:lastmodified":1566673443,
+    "wof:lastmodified":1582319480,
     "wof:name":"La Exposicion",
     "wof:parent_id":421196975,
     "wof:placetype":"localadmin",

--- a/data/421/188/607/421188607.geojson
+++ b/data/421/188/607/421188607.geojson
@@ -309,6 +309,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009571,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"da5b63b17da65999ee68f6530c93396d",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
         }
     ],
     "wof:id":421188607,
-    "wof:lastmodified":1566673443,
+    "wof:lastmodified":1582319480,
     "wof:name":"Salamanca",
     "wof:parent_id":1108693211,
     "wof:placetype":"localadmin",

--- a/data/421/188/609/421188609.geojson
+++ b/data/421/188/609/421188609.geojson
@@ -68,6 +68,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009571,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74015625cceff47c76dc950f5eedeec3",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":421188609,
-    "wof:lastmodified":1566673443,
+    "wof:lastmodified":1582319480,
     "wof:name":"Nueva Providencia",
     "wof:parent_id":1108693211,
     "wof:placetype":"localadmin",

--- a/data/421/188/611/421188611.geojson
+++ b/data/421/188/611/421188611.geojson
@@ -167,6 +167,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009571,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4f59c89b41528d5d4029fb417afa22bc",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":421188611,
-    "wof:lastmodified":1566673443,
+    "wof:lastmodified":1582319480,
     "wof:name":"Santa Ana",
     "wof:parent_id":1108693219,
     "wof:placetype":"localadmin",

--- a/data/421/189/053/421189053.geojson
+++ b/data/421/189/053/421189053.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009603,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"34f09ea1d2f3b71187902ac2ed6c4346",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421189053,
-    "wof:lastmodified":1566673442,
+    "wof:lastmodified":1582319480,
     "wof:name":"Chame",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/189/055/421189055.geojson
+++ b/data/421/189/055/421189055.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009603,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8593353279e7dc6dc7b07d3b71d908f",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421189055,
-    "wof:lastmodified":1566673442,
+    "wof:lastmodified":1582319480,
     "wof:name":"Chitr\u00e9",
     "wof:parent_id":85675781,
     "wof:placetype":"county",

--- a/data/421/189/057/421189057.geojson
+++ b/data/421/189/057/421189057.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009603,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"43c6694cfaab79237805160f1b10177c",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421189057,
-    "wof:lastmodified":1566673443,
+    "wof:lastmodified":1582319480,
     "wof:name":"La Pintada",
     "wof:parent_id":85675771,
     "wof:placetype":"county",

--- a/data/421/189/059/421189059.geojson
+++ b/data/421/189/059/421189059.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009603,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"899a5875de83058603b65b681c27151d",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":421189059,
-    "wof:lastmodified":1566673443,
+    "wof:lastmodified":1582319480,
     "wof:name":"Changuinola",
     "wof:parent_id":421170139,
     "wof:placetype":"localadmin",

--- a/data/421/189/061/421189061.geojson
+++ b/data/421/189/061/421189061.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009603,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c68ba445615887a5545183bd0369d7c5",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421189061,
-    "wof:lastmodified":1566673443,
+    "wof:lastmodified":1582319480,
     "wof:name":"Las Lajas",
     "wof:parent_id":421189053,
     "wof:placetype":"localadmin",

--- a/data/421/189/063/421189063.geojson
+++ b/data/421/189/063/421189063.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009603,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"afa7035e8e2b44ab60f358fe622e7789",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":421189063,
-    "wof:lastmodified":1566673442,
+    "wof:lastmodified":1582319480,
     "wof:name":"Barrio Balboa",
     "wof:parent_id":421171337,
     "wof:placetype":"localadmin",

--- a/data/421/189/067/421189067.geojson
+++ b/data/421/189/067/421189067.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009603,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"267524ea435eff72aa88e083fffff756",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":421189067,
-    "wof:lastmodified":1566673443,
+    "wof:lastmodified":1582319480,
     "wof:name":"Chame",
     "wof:parent_id":421189053,
     "wof:placetype":"localadmin",

--- a/data/421/189/475/421189475.geojson
+++ b/data/421/189/475/421189475.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009626,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c21abba36b4f7347190c66508ff2748f",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189475,
-    "wof:lastmodified":1566673442,
+    "wof:lastmodified":1582319480,
     "wof:name":"Jose Domingo Espinar",
     "wof:parent_id":421175375,
     "wof:placetype":"localadmin",

--- a/data/421/189/481/421189481.geojson
+++ b/data/421/189/481/421189481.geojson
@@ -638,6 +638,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009626,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a535cafb441f0cd8985333e2d13be14f",
     "wof:hierarchy":[
         {
@@ -656,7 +659,7 @@
         }
     ],
     "wof:id":421189481,
-    "wof:lastmodified":1566673442,
+    "wof:lastmodified":1582319480,
     "wof:name":"Buenos Aires",
     "wof:parent_id":421189053,
     "wof:placetype":"localadmin",

--- a/data/421/190/831/421190831.geojson
+++ b/data/421/190/831/421190831.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009670,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"742524c4b54ff0372a981ccc0ea6475f",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421190831,
-    "wof:lastmodified":1566673450,
+    "wof:lastmodified":1582319481,
     "wof:name":"Ca\u00f1ita",
     "wof:parent_id":421176107,
     "wof:placetype":"localadmin",

--- a/data/421/190/833/421190833.geojson
+++ b/data/421/190/833/421190833.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009670,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90323c8c63a3c7d4eed75cb073aa99b8",
     "wof:hierarchy":[
         {
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":421190833,
-    "wof:lastmodified":1566673450,
+    "wof:lastmodified":1582319481,
     "wof:name":"Cerme\u00f0o",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/421/191/253/421191253.geojson
+++ b/data/421/191/253/421191253.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5d96a0c9690f1aca2268d940918cdacc",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421191253,
-    "wof:lastmodified":1566673450,
+    "wof:lastmodified":1582319481,
     "wof:name":"La Mesa",
     "wof:parent_id":1108693225,
     "wof:placetype":"localadmin",

--- a/data/421/191/257/421191257.geojson
+++ b/data/421/191/257/421191257.geojson
@@ -75,6 +75,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009685,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0bd7effefcac4ed96d2bdcee30ad54d1",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":421191257,
-    "wof:lastmodified":1566673449,
+    "wof:lastmodified":1582319481,
     "wof:name":"Llano Largo",
     "wof:parent_id":1108693235,
     "wof:placetype":"localadmin",

--- a/data/421/191/263/421191263.geojson
+++ b/data/421/191/263/421191263.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009686,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"47057829f9bb86953eff514d360120eb",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":421191263,
-    "wof:lastmodified":1566673450,
+    "wof:lastmodified":1582319481,
     "wof:name":"Chim\u00f3n",
     "wof:parent_id":1108693207,
     "wof:placetype":"localadmin",

--- a/data/421/191/417/421191417.geojson
+++ b/data/421/191/417/421191417.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7972183a1c2b3fbf8fa4ba782eef854c",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191417,
-    "wof:lastmodified":1566673450,
+    "wof:lastmodified":1582319481,
     "wof:name":"El Volc\u00e1n",
     "wof:parent_id":1108693195,
     "wof:placetype":"localadmin",

--- a/data/421/191/419/421191419.geojson
+++ b/data/421/191/419/421191419.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7c602b901c91a4f89b627d05323619a3",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421191419,
-    "wof:lastmodified":1566673450,
+    "wof:lastmodified":1582319481,
     "wof:name":"Bajo Boquete",
     "wof:parent_id":421175373,
     "wof:placetype":"localadmin",

--- a/data/421/191/421/421191421.geojson
+++ b/data/421/191/421/421191421.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"05ed84931342e5c1367890d3f78bcf25",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191421,
-    "wof:lastmodified":1566673450,
+    "wof:lastmodified":1582319481,
     "wof:name":"Cristobal",
     "wof:parent_id":1108693211,
     "wof:placetype":"localadmin",

--- a/data/421/191/757/421191757.geojson
+++ b/data/421/191/757/421191757.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009707,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e38d1cdd93349914ea9842ab05626ed0",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421191757,
-    "wof:lastmodified":1566673449,
+    "wof:lastmodified":1582319481,
     "wof:name":"Nat\u00e1",
     "wof:parent_id":85675771,
     "wof:placetype":"county",

--- a/data/421/192/945/421192945.geojson
+++ b/data/421/192/945/421192945.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009754,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d66ad79f1cc5c3dea01b0331e3aaf0b4",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421192945,
-    "wof:lastmodified":1566673428,
+    "wof:lastmodified":1582319479,
     "wof:name":"Pajonal",
     "wof:parent_id":1108693185,
     "wof:placetype":"localadmin",

--- a/data/421/193/027/421193027.geojson
+++ b/data/421/193/027/421193027.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009757,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e9fb9eadad8ced26f630bd3d4758904",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421193027,
-    "wof:lastmodified":1566673430,
+    "wof:lastmodified":1582319479,
     "wof:name":"Tocumen",
     "wof:parent_id":421196975,
     "wof:placetype":"localadmin",

--- a/data/421/193/477/421193477.geojson
+++ b/data/421/193/477/421193477.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009772,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4413f7fc965f7b9f23618753466d559f",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421193477,
-    "wof:lastmodified":1566673429,
+    "wof:lastmodified":1582319479,
     "wof:name":"Pedasi",
     "wof:parent_id":421202587,
     "wof:placetype":"localadmin",

--- a/data/421/193/479/421193479.geojson
+++ b/data/421/193/479/421193479.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009772,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2003bfc46a23b89c6d198fb6384cdc46",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421193479,
-    "wof:lastmodified":1566673429,
+    "wof:lastmodified":1582319479,
     "wof:name":"Ancon",
     "wof:parent_id":421203467,
     "wof:placetype":"localadmin",

--- a/data/421/194/347/421194347.geojson
+++ b/data/421/194/347/421194347.geojson
@@ -81,6 +81,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009802,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"13b3d718b72c296a2e637678e2f3f5df",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":421194347,
-    "wof:lastmodified":1566673429,
+    "wof:lastmodified":1582319479,
     "wof:name":"Los Algarrobos Arriba",
     "wof:parent_id":421171219,
     "wof:placetype":"locality",

--- a/data/421/196/973/421196973.geojson
+++ b/data/421/196/973/421196973.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e81ef0eacd89ebfc77ccb7dfb360e44",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421196973,
-    "wof:lastmodified":1566673449,
+    "wof:lastmodified":1582319481,
     "wof:name":"Pinogana",
     "wof:parent_id":85675795,
     "wof:placetype":"county",

--- a/data/421/196/975/421196975.geojson
+++ b/data/421/196/975/421196975.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ebb345431fcdc03d2f8b7666de3d77b7",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421196975,
-    "wof:lastmodified":1566673449,
+    "wof:lastmodified":1582319481,
     "wof:name":"Panam\u00e1",
     "wof:parent_id":85675789,
     "wof:placetype":"county",

--- a/data/421/197/017/421197017.geojson
+++ b/data/421/197/017/421197017.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009900,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc0dfd817016792b61dd413c6018fd7f",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":421197017,
-    "wof:lastmodified":1534379393,
+    "wof:lastmodified":1582319481,
     "wof:name":"Boca Chica",
     "wof:parent_id":1108693267,
     "wof:placetype":"localadmin",

--- a/data/421/197/261/421197261.geojson
+++ b/data/421/197/261/421197261.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009908,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3988eecf6eacb05085848fc75971eefc",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421197261,
-    "wof:lastmodified":1566673450,
+    "wof:lastmodified":1582319481,
     "wof:name":"Paja de Sombrero",
     "wof:parent_id":421169889,
     "wof:placetype":"localadmin",

--- a/data/421/197/981/421197981.geojson
+++ b/data/421/197/981/421197981.geojson
@@ -304,6 +304,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009932,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"94ae99b4e247f081a7a367ff567897b0",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         }
     ],
     "wof:id":421197981,
-    "wof:lastmodified":1566673451,
+    "wof:lastmodified":1582319481,
     "wof:name":"David",
     "wof:parent_id":421171339,
     "wof:placetype":"localadmin",

--- a/data/421/198/133/421198133.geojson
+++ b/data/421/198/133/421198133.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009938,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"098cdfb65ecabd28ca75c5027e640e0c",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421198133,
-    "wof:lastmodified":1566673447,
+    "wof:lastmodified":1582319481,
     "wof:name":"Gualaca",
     "wof:parent_id":421169889,
     "wof:placetype":"localadmin",

--- a/data/421/198/383/421198383.geojson
+++ b/data/421/198/383/421198383.geojson
@@ -75,6 +75,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459009946,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0b1e496ad9261bd615359e100af89296",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":421198383,
-    "wof:lastmodified":1566673448,
+    "wof:lastmodified":1582319481,
     "wof:name":"Capira",
     "wof:parent_id":421181905,
     "wof:placetype":"localadmin",

--- a/data/421/199/869/421199869.geojson
+++ b/data/421/199/869/421199869.geojson
@@ -81,6 +81,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010003,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1373bbbb862a8977ba829e4b55c1b26d",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":421199869,
-    "wof:lastmodified":1566673452,
+    "wof:lastmodified":1582319481,
     "wof:name":"Chepo",
     "wof:parent_id":421176107,
     "wof:placetype":"localadmin",

--- a/data/421/199/909/421199909.geojson
+++ b/data/421/199/909/421199909.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010004,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"484bf1a6c4a22f91cfc6a17d9385b484",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421199909,
-    "wof:lastmodified":1566673452,
+    "wof:lastmodified":1582319481,
     "wof:name":"Santiago",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/421/199/911/421199911.geojson
+++ b/data/421/199/911/421199911.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010004,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"824c0f960958430bb270f2d9d749ec43",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":421199911,
-    "wof:lastmodified":1566673453,
+    "wof:lastmodified":1582319481,
     "wof:name":"Hornito",
     "wof:parent_id":421169889,
     "wof:placetype":"localadmin",

--- a/data/421/199/953/421199953.geojson
+++ b/data/421/199/953/421199953.geojson
@@ -75,6 +75,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010006,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb8a1f87ce208ef04f7980fdfd374956",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":421199953,
-    "wof:lastmodified":1566673452,
+    "wof:lastmodified":1582319481,
     "wof:name":"Pese",
     "wof:parent_id":1108693253,
     "wof:placetype":"localadmin",

--- a/data/421/199/957/421199957.geojson
+++ b/data/421/199/957/421199957.geojson
@@ -75,6 +75,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010006,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"64307e1fc483cf2574394718aaec2dab",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":421199957,
-    "wof:lastmodified":1566673452,
+    "wof:lastmodified":1582319481,
     "wof:name":"Los Pozos",
     "wof:parent_id":1108693231,
     "wof:placetype":"localadmin",

--- a/data/421/200/029/421200029.geojson
+++ b/data/421/200/029/421200029.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010009,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b03dba5300658b3fbb23dfc580fc3652",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":421200029,
-    "wof:lastmodified":1566673453,
+    "wof:lastmodified":1582319481,
     "wof:name":"Pocri",
     "wof:parent_id":1108693255,
     "wof:placetype":"localadmin",

--- a/data/421/200/895/421200895.geojson
+++ b/data/421/200/895/421200895.geojson
@@ -210,6 +210,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010045,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"996aaa1ddf1c68d9156d0291d1cbe4b4",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":421200895,
-    "wof:lastmodified":1561777247,
+    "wof:lastmodified":1582319481,
     "wof:name":"Balboa",
     "wof:parent_id":421196975,
     "wof:placetype":"locality",

--- a/data/421/201/023/421201023.geojson
+++ b/data/421/201/023/421201023.geojson
@@ -529,6 +529,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010049,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a5b7992fb2ede81c206993fd6fb475b6",
     "wof:hierarchy":[
         {
@@ -540,7 +543,7 @@
         }
     ],
     "wof:id":421201023,
-    "wof:lastmodified":1566673453,
+    "wof:lastmodified":1582319482,
     "wof:name":"Santiago",
     "wof:parent_id":421199909,
     "wof:placetype":"localadmin",

--- a/data/421/201/031/421201031.geojson
+++ b/data/421/201/031/421201031.geojson
@@ -75,6 +75,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010049,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"21aa7694c466514e15fb57607914246e",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":421201031,
-    "wof:lastmodified":1566673454,
+    "wof:lastmodified":1582319482,
     "wof:name":"Escobal",
     "wof:parent_id":1108693211,
     "wof:placetype":"localadmin",

--- a/data/421/201/561/421201561.geojson
+++ b/data/421/201/561/421201561.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010076,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fcff99bd3e8f97338af70e4dc748a3f8",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421201561,
-    "wof:lastmodified":1566673453,
+    "wof:lastmodified":1582319481,
     "wof:name":"Bastimentos",
     "wof:parent_id":1108693191,
     "wof:placetype":"localadmin",

--- a/data/421/201/563/421201563.geojson
+++ b/data/421/201/563/421201563.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010076,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb2e811669837954ec31246079c7831d",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":421201563,
-    "wof:lastmodified":1566673454,
+    "wof:lastmodified":1582319482,
     "wof:name":"Cerro Punta",
     "wof:parent_id":1108693195,
     "wof:placetype":"localadmin",

--- a/data/421/202/587/421202587.geojson
+++ b/data/421/202/587/421202587.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010123,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35eff9990770a9df0a1658e35a0603eb",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421202587,
-    "wof:lastmodified":1566673435,
+    "wof:lastmodified":1582319480,
     "wof:name":"Pedas\u00ed",
     "wof:parent_id":85675785,
     "wof:placetype":"county",

--- a/data/421/202/589/421202589.geojson
+++ b/data/421/202/589/421202589.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010123,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c1122cd0a22d3deb0b5fa84855c9d59",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421202589,
-    "wof:lastmodified":1566673435,
+    "wof:lastmodified":1582319479,
     "wof:name":"Penonom\u00e9",
     "wof:parent_id":85675771,
     "wof:placetype":"county",

--- a/data/421/202/705/421202705.geojson
+++ b/data/421/202/705/421202705.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010127,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"da8fed2205b503d496354c98c9fcdd41",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421202705,
-    "wof:lastmodified":1566673435,
+    "wof:lastmodified":1582319480,
     "wof:name":"Alanje",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/203/467/421203467.geojson
+++ b/data/421/203/467/421203467.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010153,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"25a592d6e3f9311971f1e321cae48f19",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421203467,
-    "wof:lastmodified":1566673434,
+    "wof:lastmodified":1582319479,
     "wof:name":"Arraijan",
     "wof:parent_id":1108805611,
     "wof:placetype":"county",

--- a/data/421/203/469/421203469.geojson
+++ b/data/421/203/469/421203469.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010153,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38e5d3c1033c3cdc45f2a14e130647bf",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421203469,
-    "wof:lastmodified":1566673434,
+    "wof:lastmodified":1582319479,
     "wof:name":"Tonos\u00ed",
     "wof:parent_id":85675785,
     "wof:placetype":"county",

--- a/data/421/205/063/421205063.geojson
+++ b/data/421/205/063/421205063.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"PA",
     "wof:created":1459010211,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1622624c99651a80ef47e24820d8a01",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":421205063,
-    "wof:lastmodified":1566673436,
+    "wof:lastmodified":1582319480,
     "wof:name":"El Guasimo",
     "wof:parent_id":1108693235,
     "wof:placetype":"localadmin",

--- a/data/856/321/79/85632179.geojson
+++ b/data/856/321/79/85632179.geojson
@@ -917,6 +917,11 @@
     },
     "wof:country":"PA",
     "wof:country_alpha3":"PAN",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"350282a1f6702fdcb3370b0e60c0f72d",
     "wof:hierarchy":[
         {
@@ -931,7 +936,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673079,
+    "wof:lastmodified":1582319472,
     "wof:name":"Panama",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/757/67/85675767.geojson
+++ b/data/856/757/67/85675767.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Chiriqu\u00ed Province"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"647743454a9c7b95ae76f6a3f679853d",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673077,
+    "wof:lastmodified":1582319471,
     "wof:name":"Chiriqu\u00ed",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/71/85675771.geojson
+++ b/data/856/757/71/85675771.geojson
@@ -301,6 +301,9 @@
         "wk:page":"Cocl\u00e9 Province"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d992827002ba2009f93e5b634f1fbdf",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673078,
+    "wof:lastmodified":1582319471,
     "wof:name":"Cocl\u00e9",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/75/85675775.geojson
+++ b/data/856/757/75/85675775.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Col\u00f3n Province"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2634ba74000709b0ccc9528f53a3326b",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673078,
+    "wof:lastmodified":1582319471,
     "wof:name":"Col\u00f3n",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/81/85675781.geojson
+++ b/data/856/757/81/85675781.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Herrera Province"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9e3e87cbc004a2b64ff449e87156bf87",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673078,
+    "wof:lastmodified":1582319471,
     "wof:name":"Herrera",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/85/85675785.geojson
+++ b/data/856/757/85/85675785.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Los Santos Province"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5be0d442094281aaeaa9ff0cbd518e9e",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673078,
+    "wof:lastmodified":1582319471,
     "wof:name":"Los Santos",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/89/85675789.geojson
+++ b/data/856/757/89/85675789.geojson
@@ -266,6 +266,9 @@
         "wk:page":"Panam\u00e1 Province"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb0ab21ab8c770e1bd60cbcbc6126147",
     "wof:hierarchy":[
         {
@@ -281,7 +284,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673077,
+    "wof:lastmodified":1582319471,
     "wof:name":"Panama",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/91/85675791.geojson
+++ b/data/856/757/91/85675791.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Veraguas Province"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77f7e0c2b3516814ac86f94ce00e9b49",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673078,
+    "wof:lastmodified":1582319471,
     "wof:name":"Veraguas",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/95/85675795.geojson
+++ b/data/856/757/95/85675795.geojson
@@ -301,6 +301,9 @@
         "wk:page":"Dari\u00e9n Province"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8dc21137f35230fffe5458bae395963d",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673076,
+    "wof:lastmodified":1582319470,
     "wof:name":"Dari\u00e9n",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/758/01/85675801.geojson
+++ b/data/856/758/01/85675801.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Guna Yala"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5d02e2b21274d0e88d6625e6a403b5f",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673076,
+    "wof:lastmodified":1582319470,
     "wof:name":"Kuna Yala",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/758/05/85675805.geojson
+++ b/data/856/758/05/85675805.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Bocas del Toro Province"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"255a4b2dce8870697c86b0f4355c7357",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673075,
+    "wof:lastmodified":1582319470,
     "wof:name":"Bocas del Toro",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/758/07/85675807.geojson
+++ b/data/856/758/07/85675807.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Ng\u00e4be-Bugl\u00e9 Comarca"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"71dbc480d2146764598923e26dea529f",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673076,
+    "wof:lastmodified":1582319470,
     "wof:name":"Ng\u00f6be Bugl\u00e9",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/758/11/85675811.geojson
+++ b/data/856/758/11/85675811.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Comarca Ember\u00e1-Wounaan"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ef0f96befe758ff837759a8b6e50c8e9",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566673076,
+    "wof:lastmodified":1582319470,
     "wof:name":"Ember\u00e1",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/857/639/41/85763941.geojson
+++ b/data/857/639/41/85763941.geojson
@@ -140,6 +140,9 @@
         "qs_pg:id":297522
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"283179b300639b03665a406bf1ced137",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673074,
+    "wof:lastmodified":1582319469,
     "wof:name":"Bella Vista",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/47/85763947.geojson
+++ b/data/857/639/47/85763947.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1341375
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"281ef5535719914fa03433cf19e7e321",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673075,
+    "wof:lastmodified":1582319469,
     "wof:name":"Boca la Caja",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/49/85763949.geojson
+++ b/data/857/639/49/85763949.geojson
@@ -82,6 +82,9 @@
         "qs_pg:id":1082641
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"379a332f84721c811860ea5615a8b78c",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673075,
+    "wof:lastmodified":1582319469,
     "wof:name":"Calidonia",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/53/85763953.geojson
+++ b/data/857/639/53/85763953.geojson
@@ -75,6 +75,9 @@
         "qs:id":1082642
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f84bc8e3b763c876fe8dc35bb253a1ab",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379394,
+    "wof:lastmodified":1582319469,
     "wof:name":"Campo Alegre",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/57/85763957.geojson
+++ b/data/857/639/57/85763957.geojson
@@ -75,6 +75,9 @@
         "qs:id":1174583
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd1026146d5fb3a539e6b78fecccf2d6",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379394,
+    "wof:lastmodified":1582319469,
     "wof:name":"Coco del Mar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/59/85763959.geojson
+++ b/data/857/639/59/85763959.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":982664
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"209ec0af9198cfc72a38c14778449ca9",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673073,
+    "wof:lastmodified":1582319469,
     "wof:name":"Dolequita",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/63/85763963.geojson
+++ b/data/857/639/63/85763963.geojson
@@ -75,6 +75,9 @@
         "qs:id":1082647
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bdcc5ce64ca62ea7a4aada7233fdc541",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379393,
+    "wof:lastmodified":1582319469,
     "wof:name":"El Cangrejo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/65/85763965.geojson
+++ b/data/857/639/65/85763965.geojson
@@ -75,6 +75,9 @@
         "qs:id":1082650
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3479c9da0a86067d5603ce1ae4175347",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379394,
+    "wof:lastmodified":1582319469,
     "wof:name":"El Carmen",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/67/85763967.geojson
+++ b/data/857/639/67/85763967.geojson
@@ -219,6 +219,9 @@
         "qs_pg:id":211121
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8abe71bec0d32a1e22fd198d611065d8",
     "wof:hierarchy":[
         {
@@ -234,7 +237,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673074,
+    "wof:lastmodified":1582319469,
     "wof:name":"El Dorado",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/69/85763969.geojson
+++ b/data/857/639/69/85763969.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":982666
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"61edf931361a804667f8120a792a9d63",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673074,
+    "wof:lastmodified":1582319469,
     "wof:name":"El Varital",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/71/85763971.geojson
+++ b/data/857/639/71/85763971.geojson
@@ -101,6 +101,9 @@
         "qs_pg:id":494922
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cdb7f5099e7f872cb27e18f154b6fe2c",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673075,
+    "wof:lastmodified":1582319469,
     "wof:name":"El Vedado",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/73/85763973.geojson
+++ b/data/857/639/73/85763973.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q3071317"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de937d872725e7ade0d7bf2a44bcc1ad",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379394,
+    "wof:lastmodified":1582319469,
     "wof:name":"La Carrasquilla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/75/85763975.geojson
+++ b/data/857/639/75/85763975.geojson
@@ -77,6 +77,9 @@
         "qs_pg:id":240947
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e1defd16e85ab3f162863766f5e767e",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673074,
+    "wof:lastmodified":1582319469,
     "wof:name":"La Exposici\u00f3n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/77/85763977.geojson
+++ b/data/857/639/77/85763977.geojson
@@ -75,6 +75,9 @@
         "qs:id":240948
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"06a2dd7a3c888c98001d5ad008fe2683",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379393,
+    "wof:lastmodified":1582319469,
     "wof:name":"La Florida",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/81/85763981.geojson
+++ b/data/857/639/81/85763981.geojson
@@ -106,6 +106,9 @@
         "wd:id":"Q21154277"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"534d0c00e8a71a4ce767a45d094bf49a",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673074,
+    "wof:lastmodified":1582319469,
     "wof:name":"Llano Bonito",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/83/85763983.geojson
+++ b/data/857/639/83/85763983.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":474978
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8c04ef05d99e806c21f37330e2f02ac",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673075,
+    "wof:lastmodified":1582319469,
     "wof:name":"Loma Alegre",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/85/85763985.geojson
+++ b/data/857/639/85/85763985.geojson
@@ -128,6 +128,9 @@
         "qs_pg:id":474983
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57b5ec81883a5b5ecca8d3bc7641a038",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673075,
+    "wof:lastmodified":1582319469,
     "wof:name":"Miraflores",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/87/85763987.geojson
+++ b/data/857/639/87/85763987.geojson
@@ -84,6 +84,10 @@
         "qs_pg:id":887570
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"964b78f083dc70c531ed6d7fb7dd78be",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673074,
+    "wof:lastmodified":1582319469,
     "wof:name":"Nuevo Crist\u00f3bal",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/91/85763991.geojson
+++ b/data/857/639/91/85763991.geojson
@@ -75,6 +75,9 @@
         "qs:id":1165214
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa01110f1dfe0563cd987e766b4c442f",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379394,
+    "wof:lastmodified":1582319469,
     "wof:name":"Paitilla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/639/95/85763995.geojson
+++ b/data/857/639/95/85763995.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q6062305"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3a352a6e128ef6424e031a3956944bf",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379394,
+    "wof:lastmodified":1582319469,
     "wof:name":"Parque Lefevre",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/01/85764001.geojson
+++ b/data/857/640/01/85764001.geojson
@@ -77,6 +77,9 @@
         "qs:id":887571
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3f422fbef1264a59c4a4b60ba7cd4a9",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379394,
+    "wof:lastmodified":1582319469,
     "wof:name":"Plaza la Ceda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/05/85764005.geojson
+++ b/data/857/640/05/85764005.geojson
@@ -79,6 +79,9 @@
         "qs:id":474995
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c1a09f5c0f665260e4857b4c0c4caad",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379394,
+    "wof:lastmodified":1582319469,
     "wof:name":"Pueblo Nuevo de Las Sabanas",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/09/85764009.geojson
+++ b/data/857/640/09/85764009.geojson
@@ -81,6 +81,9 @@
         "wk:page":"R\u00edo Abajo"
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fde1687eb1b3b406e3d86c4eef6ede71",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379394,
+    "wof:lastmodified":1582319469,
     "wof:name":"R\u00edo Abajo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/13/85764013.geojson
+++ b/data/857/640/13/85764013.geojson
@@ -108,6 +108,9 @@
         "qs_pg:id":1082660
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d5caa8d3931766ba4e09abb9140bfa9c",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673073,
+    "wof:lastmodified":1582319469,
     "wof:name":"San Francisco de la Caleta",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/19/85764019.geojson
+++ b/data/857/640/19/85764019.geojson
@@ -123,6 +123,9 @@
         "qs_pg:id":1033448
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a73a9ef6ea41c63111f8e1a67444cce4",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566673073,
+    "wof:lastmodified":1582319469,
     "wof:name":"Veranillo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/640/21/85764021.geojson
+++ b/data/857/640/21/85764021.geojson
@@ -75,6 +75,9 @@
         "qs:id":297823
     },
     "wof:country":"PA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a66b5ed02873b6db650359ff4311362",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379394,
+    "wof:lastmodified":1582319469,
     "wof:name":"Villa Guadalupe",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/438/873/890438873.geojson
+++ b/data/890/438/873/890438873.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"PA",
     "wof:created":1469052212,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f1e16c77dd1190a0a18f2cd7f6e01ee",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890438873,
-    "wof:lastmodified":1566673468,
+    "wof:lastmodified":1582319483,
     "wof:name":"La Palma",
     "wof:parent_id":1108693219,
     "wof:placetype":"locality",

--- a/data/890/445/081/890445081.geojson
+++ b/data/890/445/081/890445081.geojson
@@ -544,6 +544,9 @@
     },
     "wof:country":"PA",
     "wof:created":1469052496,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"f202fa73c8968ec05aca4fbfcce27707",
     "wof:hierarchy":[
         {
@@ -555,7 +558,7 @@
         }
     ],
     "wof:id":890445081,
-    "wof:lastmodified":1566673469,
+    "wof:lastmodified":1582319483,
     "wof:name":"Panam\u00e1",
     "wof:parent_id":421196975,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.