### PR TITLE
Standardize on unknown source

### DIFF
--- a/data/102/546/973/102546973.geojson
+++ b/data/102/546/973/102546973.geojson
@@ -18,7 +18,7 @@
         "PVE",
         "KPVE"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":62,
     "woe:hierarchy":{
@@ -39,7 +39,7 @@
         "icao:code":"KPVE"
     },
     "wof:country":"PA",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102546973,
@@ -48,7 +48,7 @@
         }
     ],
     "wof:id":102546973,
-    "wof:lastmodified":1566673001,
+    "wof:lastmodified":1589218812,
     "wof:name":"El Porvenir Airport",
     "wof:parent_id":85675801,
     "wof:placetype":"campus",
@@ -65,5 +65,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst/whosonfirst-sources/issues/112.

Swaps any "missing" values in `src:geom` properties to "unknown". I also checked values in `src:geom_alt` and `wof:geom_alt` properties, but there were no cases.

No PIP required, can merge once approved.