### PR TITLE
pa concordances, placetype local, and more

### DIFF
--- a/data/110/869/318/3/1108693183.geojson
+++ b/data/110/869/318/3/1108693183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038815,
-    "geom:area_square_m":475036436.120146,
+    "geom:area_square_m":475036458.840527,
     "geom:bbox":"-80.74557,8.093201,-80.473274,8.326651",
     "geom:latitude":8.209287,
     "geom:longitude":-80.604999,
@@ -106,9 +106,10 @@
         "hasc:id":"PA.CC.AG",
         "wd:id":"Q2216595"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328564,
-    "wof:geomhash":"7dc481f2d17ef38b7f49e0df2a973083",
+    "wof:geomhash":"355f22df5fa2a852d94293d5c0fb8f8e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108693183,
-    "wof:lastmodified":1690850307,
+    "wof:lastmodified":1695886124,
     "wof:name":"Aguadulce",
     "wof:parent_id":85675771,
     "wof:placetype":"county",

--- a/data/110/869/318/5/1108693185.geojson
+++ b/data/110/869/318/5/1108693185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060434,
-    "geom:area_square_m":739175787.314465,
+    "geom:area_square_m":739176057.784142,
     "geom:bbox":"-80.386713,8.288083,-80.045615,8.657202",
     "geom:latitude":8.446627,
     "geom:longitude":-80.203599,
@@ -94,9 +94,10 @@
         "hasc:id":"PA.CC.AN",
         "wd:id":"Q2216997"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328566,
-    "wof:geomhash":"51b3efc667b83ba5e6debfdada658434",
+    "wof:geomhash":"8d7b17854322b9fc594fc8841785e23c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693185,
-    "wof:lastmodified":1690850307,
+    "wof:lastmodified":1695886124,
     "wof:name":"Ant\u00f3n",
     "wof:parent_id":85675771,
     "wof:placetype":"county",

--- a/data/110/869/318/7/1108693187.geojson
+++ b/data/110/869/318/7/1108693187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012724,
-    "geom:area_square_m":155797774.47913,
+    "geom:area_square_m":155797887.71213,
     "geom:bbox":"-80.974609,7.947825,-80.842603,8.085554",
     "geom:latitude":8.017716,
     "geom:longitude":-80.910613,
@@ -94,9 +94,10 @@
         "hasc:id":"PA.VR.AT",
         "wd:id":"Q1650993"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328569,
-    "wof:geomhash":"903df6f994e26af551588443594177be",
+    "wof:geomhash":"639bd4f44cc66600e480040f0b1d896c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693187,
-    "wof:lastmodified":1690850307,
+    "wof:lastmodified":1695886124,
     "wof:name":"Atalaya",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/110/869/318/9/1108693189.geojson
+++ b/data/110/869/318/9/1108693189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048913,
-    "geom:area_square_m":598456117.154037,
+    "geom:area_square_m":598455734.18755,
     "geom:bbox":"-83.052241,8.028139,-82.703198,8.582205",
     "geom:latitude":8.321569,
     "geom:longitude":-82.881396,
@@ -94,9 +94,10 @@
         "hasc:id":"PA.CH.BR",
         "wd:id":"Q522183"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328571,
-    "wof:geomhash":"f50e85aa59aeafca15a529b89810a4e1",
+    "wof:geomhash":"7a07bac1e6c55c07c8dac23f74735f0d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693189,
-    "wof:lastmodified":1690850307,
+    "wof:lastmodified":1695886124,
     "wof:name":"Bar\u00fa",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/110/869/319/1/1108693191.geojson
+++ b/data/110/869/319/1/1108693191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037489,
-    "geom:area_square_m":457566860.786722,
+    "geom:area_square_m":457567185.432972,
     "geom:bbox":"-82.42972,9.022421,-82.008163,9.443417",
     "geom:latitude":9.221106,
     "geom:longitude":-82.251195,
@@ -103,9 +103,10 @@
         "hasc:id":"PA.BC.BT",
         "wd:id":"Q2702428"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328573,
-    "wof:geomhash":"4a8689e4a58dd296663d436b16265ed7",
+    "wof:geomhash":"f45a3e79adfb7b8e990d53f53dcfdb40",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108693191,
-    "wof:lastmodified":1690850308,
+    "wof:lastmodified":1695886124,
     "wof:name":"Bocas Del Toro",
     "wof:parent_id":85675805,
     "wof:placetype":"county",

--- a/data/110/869/319/3/1108693193.geojson
+++ b/data/110/869/319/3/1108693193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023889,
-    "geom:area_square_m":292052538.250846,
+    "geom:area_square_m":292053003.696821,
     "geom:bbox":"-82.626076,8.450833,-82.52083,8.806056",
     "geom:latitude":8.617392,
     "geom:longitude":-82.573503,
@@ -94,9 +94,10 @@
         "hasc:id":"PA.CH.BN",
         "wd:id":"Q2216576"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328575,
-    "wof:geomhash":"b6f1a6dc4f2b59dc1544ea46c4894617",
+    "wof:geomhash":"75036d2499044bffdb086f9cf5992c61",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693193,
-    "wof:lastmodified":1690850309,
+    "wof:lastmodified":1695886594,
     "wof:name":"Boquer\u00f3n",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/110/869/319/5/1108693195.geojson
+++ b/data/110/869/319/5/1108693195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071485,
-    "geom:area_square_m":873848548.624179,
+    "geom:area_square_m":873848066.544891,
     "geom:bbox":"-82.836724,8.439266,-82.540454,8.918215",
     "geom:latitude":8.660645,
     "geom:longitude":-82.678587,
@@ -100,9 +100,10 @@
         "hasc:id":"PA.CH.BG",
         "wd:id":"Q955035"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328577,
-    "wof:geomhash":"26d178f9e3d8f042b42a9e4cb7d9298d",
+    "wof:geomhash":"5fe44c31fd8359855ae85c6b73c76eab",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108693195,
-    "wof:lastmodified":1690850309,
+    "wof:lastmodified":1695886125,
     "wof:name":"Bugaba",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/110/869/319/9/1108693199.geojson
+++ b/data/110/869/319/9/1108693199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066524,
-    "geom:area_square_m":813822727.732671,
+    "geom:area_square_m":813823061.856375,
     "geom:bbox":"-80.951256,8.178205,-80.701297,8.595713",
     "geom:latitude":8.36871,
     "geom:longitude":-80.83192,
@@ -86,9 +86,10 @@
         "hasc:id":"PA.VR.CB",
         "wd:id":"Q921735"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328579,
-    "wof:geomhash":"be21405d8b49e770ac6e345d9243781b",
+    "wof:geomhash":"507da4a629c399598a7f8ca95288dbe3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108693199,
-    "wof:lastmodified":1627522489,
+    "wof:lastmodified":1695886126,
     "wof:name":"Calobre",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/110/869/320/1/1108693201.geojson
+++ b/data/110/869/320/1/1108693201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066781,
-    "geom:area_square_m":816994247.020039,
+    "geom:area_square_m":816994362.607889,
     "geom:bbox":"-81.488815,8.244856,-81.091029,8.51588",
     "geom:latitude":8.358524,
     "geom:longitude":-81.285268,
@@ -86,9 +86,10 @@
         "hasc:id":"PA.VR.CZ",
         "wd:id":"Q1651005"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328581,
-    "wof:geomhash":"247d177be75dc27e9eff30a9a10ea127",
+    "wof:geomhash":"5591e03d1d05e4384efa04da80125d35",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108693201,
-    "wof:lastmodified":1627522489,
+    "wof:lastmodified":1695886126,
     "wof:name":"Ca\u00f1azas",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/110/869/320/3/1108693203.geojson
+++ b/data/110/869/320/3/1108693203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.243494,
-    "geom:area_square_m":2978361640.119171,
+    "geom:area_square_m":2978360945.59509,
     "geom:bbox":"-77.926233,8.055644,-77.284593,8.791332",
     "geom:latitude":8.422846,
     "geom:longitude":-77.612906,
@@ -97,9 +97,10 @@
         "hasc:id":"PA.EM.CE",
         "wd:id":"Q3710848"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328582,
-    "wof:geomhash":"c99b0d7888b509d11b33ed2a3a648aa8",
+    "wof:geomhash":"67ea9cf6b6914071315c439816c0bd71",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108693203,
-    "wof:lastmodified":1690850306,
+    "wof:lastmodified":1695886126,
     "wof:name":"C\u00e9maco",
     "wof:parent_id":85675811,
     "wof:placetype":"county",

--- a/data/110/869/320/5/1108693205.geojson
+++ b/data/110/869/320/5/1108693205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037605,
-    "geom:area_square_m":459101148.234682,
+    "geom:area_square_m":459101323.198681,
     "geom:bbox":"-80.201393,8.950767,-79.987984,9.286908",
     "geom:latitude":9.132791,
     "geom:longitude":-80.106641,
@@ -94,9 +94,10 @@
         "hasc:id":"PA.CL.CR",
         "wd:id":"Q2786644"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328584,
-    "wof:geomhash":"878f1c54689a4049a41f45bbba936b0c",
+    "wof:geomhash":"8cf4e1b4203edfd3fb0f49a06a2edc13",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693205,
-    "wof:lastmodified":1690850306,
+    "wof:lastmodified":1695886126,
     "wof:name":"Chagres",
     "wof:parent_id":85675775,
     "wof:placetype":"county",

--- a/data/110/869/320/7/1108693207.geojson
+++ b/data/110/869/320/7/1108693207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083458,
-    "geom:area_square_m":1019894582.430371,
+    "geom:area_square_m":1019895290.457374,
     "geom:bbox":"-78.916664,8.360806,-78.41854,8.968449",
     "geom:latitude":8.774887,
     "geom:longitude":-78.644025,
@@ -89,9 +89,10 @@
         "hasc:id":"PA.PN.CN",
         "wd:id":"Q2216594"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328588,
-    "wof:geomhash":"d42e458bd7cabf75e1635700292aa9de",
+    "wof:geomhash":"8b658c0081f474ee1cf6713dfe3361f7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693207,
-    "wof:lastmodified":1627522489,
+    "wof:lastmodified":1695886126,
     "wof:name":"Chim\u00e1n",
     "wof:parent_id":85675789,
     "wof:placetype":"county",

--- a/data/110/869/320/9/1108693209.geojson
+++ b/data/110/869/320/9/1108693209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017395,
-    "geom:area_square_m":212460176.81791,
+    "geom:area_square_m":212459973.987906,
     "geom:bbox":"-82.323135,8.856011,-82.029896,9.135086",
     "geom:latitude":8.981524,
     "geom:longitude":-82.20287,
@@ -97,9 +97,10 @@
         "hasc:id":"PA.BC.CG",
         "wd:id":"Q515794"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328590,
-    "wof:geomhash":"9ddd7a10617ea58393778c98f72f00c5",
+    "wof:geomhash":"855e7c65fae13ed597243c18156525f3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108693209,
-    "wof:lastmodified":1690850306,
+    "wof:lastmodified":1695886126,
     "wof:name":"Chiriqu\u00ed Grande",
     "wof:parent_id":85675805,
     "wof:placetype":"county",

--- a/data/110/869/321/1/1108693211.geojson
+++ b/data/110/869/321/1/1108693211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12031,
-    "geom:area_square_m":1468336107.181064,
+    "geom:area_square_m":1468337126.01589,
     "geom:bbox":"-80.105967,8.959416,-79.535978,9.477513",
     "geom:latitude":9.243652,
     "geom:longitude":-79.81305,
@@ -94,9 +94,10 @@
         "hasc:id":"PA.CL.CL",
         "wd:id":"Q2071684"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328592,
-    "wof:geomhash":"cf761c3f930a9afbb7e53634323bedd4",
+    "wof:geomhash":"dc50f0a6a87efe22b0f38a47fa5d4ee2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693211,
-    "wof:lastmodified":1690850310,
+    "wof:lastmodified":1695886126,
     "wof:name":"Col\u00f3n",
     "wof:parent_id":85675775,
     "wof:placetype":"county",

--- a/data/110/869/321/3/1108693213.geojson
+++ b/data/110/869/321/3/1108693213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.186971,
-    "geom:area_square_m":2282517394.403632,
+    "geom:area_square_m":2282517394.404227,
     "geom:bbox":"-79.278296,8.520338,-77.357987,9.564917",
     "geom:latitude":9.145604,
     "geom:longitude":-78.270912,
@@ -66,12 +66,13 @@
     "wof:concordances":{
         "hasc:id":"PA.SB.KY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85675801
     ],
     "wof:country":"PA",
     "wof:created":1474328594,
-    "wof:geomhash":"ad5290256dd9ec218f7b8dab68b48a87",
+    "wof:geomhash":"3bb5d7e83bf4293797b3a3b7842df226",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108693213,
-    "wof:lastmodified":1627522490,
+    "wof:lastmodified":1695886126,
     "wof:name":"Comarca Kuna Yala",
     "wof:parent_id":85675801,
     "wof:placetype":"county",

--- a/data/110/869/321/7/1108693217.geojson
+++ b/data/110/869/321/7/1108693217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.151357,
-    "geom:area_square_m":1848699786.205562,
+    "geom:area_square_m":1848699983.377932,
     "geom:bbox":"-80.873091,8.624301,-80.190466,9.196",
     "geom:latitude":8.962355,
     "geom:longitude":-80.521524,
@@ -89,9 +89,10 @@
         "hasc:id":"PA.CL.DN",
         "wd:id":"Q2217007"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328597,
-    "wof:geomhash":"07fd5d215988d7de52b7b81f56cbf546",
+    "wof:geomhash":"5adf454848cecacd6609b8ec4148426c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693217,
-    "wof:lastmodified":1627522490,
+    "wof:lastmodified":1695886126,
     "wof:name":"Donoso",
     "wof:parent_id":85675775,
     "wof:placetype":"county",

--- a/data/110/869/321/9/1108693219.geojson
+++ b/data/110/869/321/9/1108693219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01771,
-    "geom:area_square_m":216977093.36813,
+    "geom:area_square_m":216977182.058909,
     "geom:bbox":"-80.438535,7.63637,-80.243986,7.899383",
     "geom:latitude":7.777473,
     "geom:longitude":-80.35387,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"PA.LS.GR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328599,
-    "wof:geomhash":"523ec62f7f6ad3fab9c9d26d7659caeb",
+    "wof:geomhash":"50f8d8a250f98332e0e0f66631ceaacf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108693219,
-    "wof:lastmodified":1627522490,
+    "wof:lastmodified":1695886127,
     "wof:name":"Guarar\u00e9",
     "wof:parent_id":85675785,
     "wof:placetype":"county",

--- a/data/110/869/322/1/1108693221.geojson
+++ b/data/110/869/322/1/1108693221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.199478,
-    "geom:area_square_m":2437596574.913168,
+    "geom:area_square_m":2437596947.637708,
     "geom:bbox":"-82.420781,8.498186,-81.613183,9.146045",
     "geom:latitude":8.792121,
     "geom:longitude":-81.980882,
@@ -85,9 +85,10 @@
         "hasc:id":"PA.NB.KK",
         "wd:id":"Q2659227"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328600,
-    "wof:geomhash":"3db20b6c3a5dedb9c025124fa543e287",
+    "wof:geomhash":"3e716d35ba9de192721b5d2b9f5ce6a0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108693221,
-    "wof:lastmodified":1690850305,
+    "wof:lastmodified":1695886127,
     "wof:name":"Kankint\u00fa",
     "wof:parent_id":85675807,
     "wof:placetype":"county",

--- a/data/110/869/322/3/1108693223.geojson
+++ b/data/110/869/322/3/1108693223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144361,
-    "geom:area_square_m":1764225317.939077,
+    "geom:area_square_m":1764225236.281044,
     "geom:bbox":"-81.949364,8.499052,-81.15734,9.18825",
     "geom:latitude":8.75981,
     "geom:longitude":-81.511683,
@@ -94,9 +94,10 @@
         "hasc:id":"PA.NB.KS",
         "wd:id":"Q751010"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328602,
-    "wof:geomhash":"6ef3b00fb5672a0616d886fa429356ad",
+    "wof:geomhash":"8260f4cf824efa311b8506ac8d537284",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693223,
-    "wof:lastmodified":1690850305,
+    "wof:lastmodified":1695886127,
     "wof:name":"Kusap\u00edn",
     "wof:parent_id":85675807,
     "wof:placetype":"county",

--- a/data/110/869/322/5/1108693225.geojson
+++ b/data/110/869/322/5/1108693225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042374,
-    "geom:area_square_m":518649877.56799,
+    "geom:area_square_m":518649877.567932,
     "geom:bbox":"-81.3880920344,8.037896393,-81.0858035245,8.26793077977",
     "geom:latitude":8.168632,
     "geom:longitude":-81.225659,
@@ -89,9 +89,10 @@
         "hasc:id":"PA.VR.LM",
         "wd:id":"Q2216424"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328604,
-    "wof:geomhash":"09b7e314805f2823dca4e68711b0c6cf",
+    "wof:geomhash":"88ab3d255c7cebf1c1ceea40ff2d02be",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693225,
-    "wof:lastmodified":1566673329,
+    "wof:lastmodified":1695886594,
     "wof:name":"La Mesa",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/110/869/322/7/1108693227.geojson
+++ b/data/110/869/322/7/1108693227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038305,
-    "geom:area_square_m":469336706.693716,
+    "geom:area_square_m":469336844.248328,
     "geom:bbox":"-80.95604,7.569312,-80.685509,7.864217",
     "geom:latitude":7.732415,
     "geom:longitude":-80.799674,
@@ -92,9 +92,10 @@
         "hasc:id":"PA.HE.LN",
         "wd:id":"Q2216080"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328606,
-    "wof:geomhash":"1db4669daf24a1caaf66ef072174f986",
+    "wof:geomhash":"06c33ace870949878d0ebec759d4edfb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108693227,
-    "wof:lastmodified":1627522490,
+    "wof:lastmodified":1695886127,
     "wof:name":"Las Minas",
     "wof:parent_id":85675781,
     "wof:placetype":"county",

--- a/data/110/869/322/9/1108693229.geojson
+++ b/data/110/869/322/9/1108693229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083343,
-    "geom:area_square_m":1020325295.682989,
+    "geom:area_square_m":1020324947.154986,
     "geom:bbox":"-81.687738,7.839389,-81.363944,8.39854",
     "geom:latitude":8.078299,
     "geom:longitude":-81.508789,
@@ -92,9 +92,10 @@
         "hasc:id":"PA.VR.LA",
         "wd:id":"Q1650981"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328608,
-    "wof:geomhash":"908c458bf009613f126fc4c0ed8db7ef",
+    "wof:geomhash":"1d2e81f70c4f3e82eca115cbb35bafd7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108693229,
-    "wof:lastmodified":1636495946,
+    "wof:lastmodified":1695886704,
     "wof:name":"Las Palmas",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/110/869/323/1/1108693231.geojson
+++ b/data/110/869/323/1/1108693231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032504,
-    "geom:area_square_m":398305641.184291,
+    "geom:area_square_m":398305606.004963,
     "geom:bbox":"-80.783321,7.538934,-80.558706,7.841196",
     "geom:latitude":7.692548,
     "geom:longitude":-80.669281,
@@ -92,9 +92,10 @@
         "hasc:id":"PA.HE.LZ",
         "wd:id":"Q2217030"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328610,
-    "wof:geomhash":"1a59e9dc8a7484d0cc752411f849a11a",
+    "wof:geomhash":"d9d46672ab06dffe8c719b9e688481f6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108693231,
-    "wof:lastmodified":1627522490,
+    "wof:lastmodified":1695886127,
     "wof:name":"Los Pozos",
     "wof:parent_id":85675781,
     "wof:placetype":"county",

--- a/data/110/869/323/5/1108693235.geojson
+++ b/data/110/869/323/5/1108693235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035152,
-    "geom:area_square_m":430570143.006435,
+    "geom:area_square_m":430570311.671081,
     "geom:bbox":"-80.590866,7.752426,-80.314152,8.005972",
     "geom:latitude":7.871086,
     "geom:longitude":-80.433294,
@@ -100,9 +100,10 @@
         "hasc:id":"PA.LS.LS",
         "wd:id":"Q2216602"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328612,
-    "wof:geomhash":"1eb8a0f6ddd80f232fe6bb8bddd8bc8c",
+    "wof:geomhash":"f160100dc222da3eb2628d2df222b5dd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108693235,
-    "wof:lastmodified":1690850304,
+    "wof:lastmodified":1695886704,
     "wof:name":"Los Santos",
     "wof:parent_id":85675785,
     "wof:placetype":"county",

--- a/data/110/869/323/7/1108693237.geojson
+++ b/data/110/869/323/7/1108693237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041276,
-    "geom:area_square_m":505832857.130188,
+    "geom:area_square_m":505832850.627022,
     "geom:bbox":"-80.714106,7.537726,-80.412607,7.813506",
     "geom:latitude":7.657935,
     "geom:longitude":-80.541537,
@@ -92,9 +92,10 @@
         "hasc:id":"PA.LS.MC",
         "wd:id":"Q2216055"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328613,
-    "wof:geomhash":"84b2a38aeb62bff88c2785082be0bedf",
+    "wof:geomhash":"a21ece9aba1f3bf460f6cea258067734",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108693237,
-    "wof:lastmodified":1627522491,
+    "wof:lastmodified":1695886127,
     "wof:name":"Macaracas",
     "wof:parent_id":85675785,
     "wof:placetype":"county",

--- a/data/110/869/323/9/1108693239.geojson
+++ b/data/110/869/323/9/1108693239.geojson
@@ -77,6 +77,7 @@
         "hasc:id":"PA.VR.MT",
         "wd:id":"Q1650967"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328615,
     "wof:geomhash":"815c805f82c2fdd099e40f86c88768a5",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108693239,
-    "wof:lastmodified":1694498067,
+    "wof:lastmodified":1695886127,
     "wof:name":"Mariato",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/110/869/324/1/1108693241.geojson
+++ b/data/110/869/324/1/1108693241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028233,
-    "geom:area_square_m":345303766.136596,
+    "geom:area_square_m":345303849.557912,
     "geom:bbox":"-81.98946,8.320402,-81.803122,8.657096",
     "geom:latitude":8.459429,
     "geom:longitude":-81.877607,
@@ -89,9 +89,10 @@
         "hasc:id":"PA.NB.MR",
         "wd:id":"Q598049"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328616,
-    "wof:geomhash":"b3d813ad2306381ef7f727785e0ddeb3",
+    "wof:geomhash":"024f1b7ce35765a346b243bc9d349159",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693241,
-    "wof:lastmodified":1690850303,
+    "wof:lastmodified":1695886128,
     "wof:name":"Miron\u00f3",
     "wof:parent_id":85675807,
     "wof:placetype":"county",

--- a/data/110/869/324/3/1108693243.geojson
+++ b/data/110/869/324/3/1108693243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065984,
-    "geom:area_square_m":807080344.116428,
+    "geom:area_square_m":807081009.098155,
     "geom:bbox":"-81.792647,8.227794,-81.496225,8.628189",
     "geom:latitude":8.434777,
     "geom:longitude":-81.631531,
@@ -88,9 +88,10 @@
         "hasc:id":"PA.NB.MU",
         "wd:id":"Q656667"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328618,
-    "wof:geomhash":"007478c1a64b7ed968ded2946573fa38",
+    "wof:geomhash":"af49375acd7f480c834f52155ea01367",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693243,
-    "wof:lastmodified":1690850303,
+    "wof:lastmodified":1695886128,
     "wof:name":"M\u00fcna",
     "wof:parent_id":85675807,
     "wof:placetype":"county",

--- a/data/110/869/324/5/1108693245.geojson
+++ b/data/110/869/324/5/1108693245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014554,
-    "geom:area_square_m":178024492.553299,
+    "geom:area_square_m":178024314.251574,
     "geom:bbox":"-81.841331,8.270148,-81.737158,8.56486",
     "geom:latitude":8.410586,
     "geom:longitude":-81.79349,
@@ -88,9 +88,10 @@
         "hasc:id":"PA.NB.ND",
         "wd:id":"Q3711257"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328621,
-    "wof:geomhash":"08c128797136cd39bf344608b3d4e4b1",
+    "wof:geomhash":"72e36238bef1d64a56d98c620bd59b71",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693245,
-    "wof:lastmodified":1690850303,
+    "wof:lastmodified":1695886128,
     "wof:name":"Nole Duima",
     "wof:parent_id":85675807,
     "wof:placetype":"county",

--- a/data/110/869/324/7/1108693247.geojson
+++ b/data/110/869/324/7/1108693247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050718,
-    "geom:area_square_m":621151139.056517,
+    "geom:area_square_m":621151112.461302,
     "geom:bbox":"-80.952524,7.773174,-80.649772,8.072473",
     "geom:latitude":7.925014,
     "geom:longitude":-80.811376,
@@ -94,9 +94,10 @@
         "hasc:id":"PA.HE.OC",
         "wd:id":"Q2216607"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328622,
-    "wof:geomhash":"0a92a60d21107f22d0e1acee632b74ea",
+    "wof:geomhash":"323bf14582b12066a9cf2fbf15ae115e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693247,
-    "wof:lastmodified":1690850303,
+    "wof:lastmodified":1695886128,
     "wof:name":"Oc\u00fa",
     "wof:parent_id":85675781,
     "wof:placetype":"county",

--- a/data/110/869/324/9/1108693249.geojson
+++ b/data/110/869/324/9/1108693249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030954,
-    "geom:area_square_m":378561568.510019,
+    "geom:area_square_m":378561400.390041,
     "geom:bbox":"-80.782596,8.368655,-80.56719,8.632597",
     "geom:latitude":8.490512,
     "geom:longitude":-80.67033,
@@ -94,9 +94,10 @@
         "hasc:id":"PA.CC.OL",
         "wd:id":"Q2217017"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328624,
-    "wof:geomhash":"8878bd26150e6726ae46a01df5e16d4a",
+    "wof:geomhash":"cef2a3ed31744fc400479b6330a57ab7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693249,
-    "wof:lastmodified":1690850302,
+    "wof:lastmodified":1695886128,
     "wof:name":"Ol\u00e1",
     "wof:parent_id":85675771,
     "wof:placetype":"county",

--- a/data/110/869/325/3/1108693253.geojson
+++ b/data/110/869/325/3/1108693253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023728,
-    "geom:area_square_m":290623910.261243,
+    "geom:area_square_m":290623858.948543,
     "geom:bbox":"-80.726703,7.809072,-80.495905,7.97829",
     "geom:latitude":7.895169,
     "geom:longitude":-80.615802,
@@ -89,9 +89,10 @@
         "hasc:id":"PA.HE.PS",
         "wd:id":"Q2217039"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328628,
-    "wof:geomhash":"6abd0adc86dc9fed367ecd2aaaef63d8",
+    "wof:geomhash":"75157c8f48bb735d6f0b40e44bf88179",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693253,
-    "wof:lastmodified":1627522491,
+    "wof:lastmodified":1695886128,
     "wof:name":"Pes\u00e9",
     "wof:parent_id":85675781,
     "wof:placetype":"county",

--- a/data/110/869/325/5/1108693255.geojson
+++ b/data/110/869/325/5/1108693255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023029,
-    "geom:area_square_m":282233440.625147,
+    "geom:area_square_m":282233667.957619,
     "geom:bbox":"-80.238645,7.525079,-80.064829,7.759336",
     "geom:latitude":7.631895,
     "geom:longitude":-80.158695,
@@ -89,9 +89,10 @@
         "hasc:id":"PA.LS.PC",
         "wd:id":"Q2216539"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328631,
-    "wof:geomhash":"792f5a0b290d605ed9d0757fc13810ba",
+    "wof:geomhash":"ac8fc30c5a60624a8fa82ecb356ce98a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693255,
-    "wof:lastmodified":1627522492,
+    "wof:lastmodified":1695886128,
     "wof:name":"Pocr\u00ed",
     "wof:parent_id":85675785,
     "wof:placetype":"county",

--- a/data/110/869/325/7/1108693257.geojson
+++ b/data/110/869/325/7/1108693257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032828,
-    "geom:area_square_m":400363709.585978,
+    "geom:area_square_m":400363511.436828,
     "geom:bbox":"-79.804352,9.367512,-79.520588,9.634694",
     "geom:latitude":9.495271,
     "geom:longitude":-79.643702,
@@ -89,9 +89,10 @@
         "hasc:id":"PA.CL.PB",
         "wd:id":"Q1650732"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328632,
-    "wof:geomhash":"cb98b06bed54d8c105db31d87a22bb68",
+    "wof:geomhash":"7c692225a4db651256a7208021803340",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693257,
-    "wof:lastmodified":1627522492,
+    "wof:lastmodified":1695886128,
     "wof:name":"Portobelo",
     "wof:parent_id":85675775,
     "wof:placetype":"county",

--- a/data/110/869/325/9/1108693259.geojson
+++ b/data/110/869/325/9/1108693259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013752,
-    "geom:area_square_m":168296107.002815,
+    "geom:area_square_m":168296107.00275,
     "geom:bbox":"-81.8617913886,8.133250237,-81.7170450556,8.31413707324",
     "geom:latitude":8.224422,
     "geom:longitude":-81.794159,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"PA.CH.RM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328634,
-    "wof:geomhash":"cc198ede47e5591682bde1eb08803974",
+    "wof:geomhash":"e4bb0c1118fb525fd2a3076ccefa95b9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108693259,
-    "wof:lastmodified":1566673329,
+    "wof:lastmodified":1695886594,
     "wof:name":"Remedios",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/110/869/326/1/1108693261.geojson
+++ b/data/110/869/326/1/1108693261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043389,
-    "geom:area_square_m":530266483.77477,
+    "geom:area_square_m":530266617.355135,
     "geom:bbox":"-82.919962,8.57491,-82.687365,8.921354",
     "geom:latitude":8.748423,
     "geom:longitude":-82.793878,
@@ -89,9 +89,10 @@
         "hasc:id":"PA.CH.RN",
         "wd:id":"Q2216549"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328635,
-    "wof:geomhash":"32898fbb7cfc278062544e079c6a0f4e",
+    "wof:geomhash":"e377667291d1bfec719f5b8f6f0cef7b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693261,
-    "wof:lastmodified":1627522492,
+    "wof:lastmodified":1695886129,
     "wof:name":"Renacimiento",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/110/869/326/3/1108693263.geojson
+++ b/data/110/869/326/3/1108693263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026034,
-    "geom:area_square_m":318825721.621114,
+    "geom:area_square_m":318825561.576313,
     "geom:bbox":"-81.245993,7.818139,-81.070511,8.073716",
     "geom:latitude":7.951424,
     "geom:longitude":-81.153434,
@@ -86,9 +86,10 @@
         "hasc:id":"PA.VR.RJ",
         "wd:id":"Q1650989"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328636,
-    "wof:geomhash":"6c2fe9efb2179741327a583f9394825b",
+    "wof:geomhash":"61075558c337b73c52f49d70b54e62c5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108693263,
-    "wof:lastmodified":1627522492,
+    "wof:lastmodified":1695886129,
     "wof:name":"R\u00edo de Jes\u00fas",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/110/869/326/5/1108693265.geojson
+++ b/data/110/869/326/5/1108693265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097432,
-    "geom:area_square_m":1193545811.969864,
+    "geom:area_square_m":1193545452.317733,
     "geom:bbox":"-78.313486,7.596049,-77.943756,8.09321",
     "geom:latitude":7.824554,
     "geom:longitude":-78.128608,
@@ -97,9 +97,10 @@
         "hasc:id":"PA.EM.SB",
         "wd:id":"Q3711428"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328638,
-    "wof:geomhash":"eae26b2bebf2c2301def1ae00e47464b",
+    "wof:geomhash":"85204c688862559c8cb55f1e7c7bc920",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108693265,
-    "wof:lastmodified":1690850309,
+    "wof:lastmodified":1695886129,
     "wof:name":"Samb\u00fa",
     "wof:parent_id":85675811,
     "wof:placetype":"county",

--- a/data/110/869/326/7/1108693267.geojson
+++ b/data/110/869/326/7/1108693267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056331,
-    "geom:area_square_m":689216443.381797,
+    "geom:area_square_m":689216595.310584,
     "geom:bbox":"-82.320305,8.161195,-81.941863,8.475752",
     "geom:latitude":8.316262,
     "geom:longitude":-82.114018,
@@ -119,9 +119,10 @@
         "hasc:id":"PA.CH.SL",
         "wd:id":"Q2071697"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328642,
-    "wof:geomhash":"58f0426d0d862e3818e09ecb4afd9228",
+    "wof:geomhash":"5197b21681fa5fd1cefed19410341107",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108693267,
-    "wof:lastmodified":1636495946,
+    "wof:lastmodified":1695886704,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/110/869/327/1/1108693271.geojson
+++ b/data/110/869/327/1/1108693271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059856,
-    "geom:area_square_m":729988100.449564,
+    "geom:area_square_m":729988618.469887,
     "geom:bbox":"-79.576955,9.3518,-79.072297,9.603167",
     "geom:latitude":9.497231,
     "geom:longitude":-79.302951,
@@ -110,9 +110,10 @@
         "hasc:id":"PA.CL.SI",
         "wd:id":"Q3585237"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328645,
-    "wof:geomhash":"e22b008176e6143bacc1760d6a6dd375",
+    "wof:geomhash":"4b589328a92f5ae9b0bf592a47c250b7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108693271,
-    "wof:lastmodified":1636495946,
+    "wof:lastmodified":1695886704,
     "wof:name":"Santa Isabel",
     "wof:parent_id":85675775,
     "wof:placetype":"county",

--- a/data/110/869/327/3/1108693273.geojson
+++ b/data/110/869/327/3/1108693273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013531,
-    "geom:area_square_m":165645923.841838,
+    "geom:area_square_m":165646083.122497,
     "geom:bbox":"-80.819113,8.044252,-80.554913,8.144549",
     "geom:latitude":8.101058,
     "geom:longitude":-80.691172,
@@ -89,9 +89,10 @@
         "hasc:id":"PA.HE.ST",
         "wd:id":"Q3711451"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328647,
-    "wof:geomhash":"cba9c27d9dd5588c2f021820d014d47b",
+    "wof:geomhash":"5bd781e5efd1f0218d41dd3495df12b4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693273,
-    "wof:lastmodified":1627522492,
+    "wof:lastmodified":1695886129,
     "wof:name":"Santa Mar\u00eda",
     "wof:parent_id":85675781,
     "wof:placetype":"county",

--- a/data/110/869/327/5/1108693275.geojson
+++ b/data/110/869/327/5/1108693275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00055,
-    "geom:area_square_m":6716382.779302,
+    "geom:area_square_m":6716292.612666,
     "geom:bbox":"-79.573387,8.773945,-79.540886,8.805056",
     "geom:latitude":8.789828,
     "geom:longitude":-79.558504,
@@ -89,9 +89,10 @@
         "hasc:id":"PA.PN.TB",
         "wd:id":"Q2072534"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328650,
-    "wof:geomhash":"cced492c970ff01731e72d4651f8283b",
+    "wof:geomhash":"54a04743790d201a83ef6f2aaaecc9b1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693275,
-    "wof:lastmodified":1627522492,
+    "wof:lastmodified":1695886129,
     "wof:name":"Taboga",
     "wof:parent_id":85675789,
     "wof:placetype":"county",

--- a/data/110/869/327/7/1108693277.geojson
+++ b/data/110/869/327/7/1108693277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040781,
-    "geom:area_square_m":499115383.306567,
+    "geom:area_square_m":499115383.30653,
     "geom:bbox":"-81.7637164732,8.00750070276,-81.5129016184,8.36660285883",
     "geom:latitude":8.194923,
     "geom:longitude":-81.647396,
@@ -95,9 +95,10 @@
         "hasc:id":"PA.CH.TL",
         "wd:id":"Q1014642"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328651,
-    "wof:geomhash":"21c784148edd998603f9411866a7e52e",
+    "wof:geomhash":"c540007567da84b56361f54fe9359d82",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108693277,
-    "wof:lastmodified":1566673331,
+    "wof:lastmodified":1695886594,
     "wof:name":"Tol\u00e9",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/110/869/327/9/1108693279.geojson
+++ b/data/110/869/327/9/1108693279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044448,
-    "geom:area_square_m":543633487.044229,
+    "geom:area_square_m":543633531.813494,
     "geom:bbox":"-81.573661,8.141533,-81.143171,8.598428",
     "geom:latitude":8.456058,
     "geom:longitude":-81.396816,
@@ -94,9 +94,10 @@
         "hasc:id":"PA.NB.NR",
         "wd:id":"Q3711636"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1474328653,
-    "wof:geomhash":"640c92ab191b65c44827e1c66acb46bd",
+    "wof:geomhash":"addfc60b6079f7a8a92976342c8cd8e4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693279,
-    "wof:lastmodified":1690850307,
+    "wof:lastmodified":1695886128,
     "wof:name":"\u00d1\u00fcr\u00fcm",
     "wof:parent_id":85675807,
     "wof:placetype":"county",

--- a/data/110/880/561/1/1108805611.geojson
+++ b/data/110/880/561/1/1108805611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.24825,
-    "geom:area_square_m":3033282516.108324,
+    "geom:area_square_m":3033281032.916072,
     "geom:bbox":"-80.172155,8.406437,-79.560753,9.19534",
     "geom:latitude":8.827273,
     "geom:longitude":-79.904311,
@@ -57,11 +57,13 @@
     "wof:concordances":{
         "fips:code":"PM13",
         "hasc:id":"PA.PO",
+        "iso:code":"PA-10",
         "iso:id":"PA-10"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:created":1485478874,
-    "wof:geomhash":"a7194cd772b0b385a4f3cbe0553231e9",
+    "wof:geomhash":"7721da5efb8211138645d21ee0398c9c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +78,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1627522491,
+    "wof:lastmodified":1695884756,
     "wof:name":"Panama Oeste",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/421/166/923/421166923.geojson
+++ b/data/421/166/923/421166923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028638,
-    "geom:area_square_m":350632745.687136,
+    "geom:area_square_m":350632839.539728,
     "geom:bbox":"-80.715851,7.950687,-80.449649,8.119951",
     "geom:latitude":8.034063,
     "geom:longitude":-80.579232,
@@ -114,12 +114,13 @@
         "qs_pg:id":114261,
         "wd:id":"Q2216637"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008707,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ba60f139ca99c3be6d6cd015708572f9",
+    "wof:geomhash":"b92d54c37c3ae7dd554a1d4e0547b13a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421166923,
-    "wof:lastmodified":1627522491,
+    "wof:lastmodified":1695886127,
     "wof:name":"Parita",
     "wof:parent_id":85675781,
     "wof:placetype":"county",

--- a/data/421/169/889/421169889.geojson
+++ b/data/421/169/889/421169889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052411,
-    "geom:area_square_m":640775179.722149,
+    "geom:area_square_m":640775223.31661,
     "geom:bbox":"-82.357246,8.423463,-82.142777,8.785819",
     "geom:latitude":8.608356,
     "geom:longitude":-82.239001,
@@ -122,12 +122,13 @@
         "qs_pg:id":1263651,
         "wd:id":"Q2216432"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008828,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"94063cc0ae4a3d1a5416c7c5fef6b6f0",
+    "wof:geomhash":"beab1e8cd91c11987a837625cd28dad7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421169889,
-    "wof:lastmodified":1690850316,
+    "wof:lastmodified":1695886697,
     "wof:name":"Gualaca",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/170/139/421170139.geojson
+++ b/data/421/170/139/421170139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.329721,
-    "geom:area_square_m":4024269178.924366,
+    "geom:area_square_m":4024269132.127394,
     "geom:bbox":"-82.936112,8.811255,-82.289381,9.618956",
     "geom:latitude":9.229236,
     "geom:longitude":-82.640005,
@@ -125,12 +125,13 @@
         "qs_pg:id":220301,
         "wd:id":"Q2216073"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008839,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"11958f3a0edc9c3d57c23f89923fd2a3",
+    "wof:geomhash":"003ceb9d736abe3da4a70a9b89136931",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421170139,
-    "wof:lastmodified":1690850347,
+    "wof:lastmodified":1695886124,
     "wof:name":"Changuinola",
     "wof:parent_id":85675805,
     "wof:placetype":"county",

--- a/data/421/170/141/421170141.geojson
+++ b/data/421/170/141/421170141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.598861,
-    "geom:area_square_m":7330641763.607227,
+    "geom:area_square_m":7330642568.994978,
     "geom:bbox":"-78.508152,7.225743,-77.691982,8.977625",
     "geom:latitude":8.116697,
     "geom:longitude":-78.074911,
@@ -119,12 +119,13 @@
         "qs_pg:id":220302,
         "wd:id":"Q1651404"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008839,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"24e448e366b63953f3934316ae878749",
+    "wof:geomhash":"c47b6d495d1363d4306e32fb2ec0fa12",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421170141,
-    "wof:lastmodified":1690850348,
+    "wof:lastmodified":1695886125,
     "wof:name":"Chepigana",
     "wof:parent_id":85675795,
     "wof:placetype":"county",

--- a/data/421/171/219/421171219.geojson
+++ b/data/421/171/219/421171219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020708,
-    "geom:area_square_m":253167456.082824,
+    "geom:area_square_m":253167021.565685,
     "geom:bbox":"-82.556752,8.477583,-82.360717,8.775284",
     "geom:latitude":8.62047,
     "geom:longitude":-82.465462,
@@ -125,12 +125,13 @@
         "qs_pg:id":1263668,
         "wd:id":"Q2216989"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008885,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d1bcb7a5bdde17389e5b53136d630bd9",
+    "wof:geomhash":"ad21097dfd3f9d42b86005f35ed8a987",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421171219,
-    "wof:lastmodified":1690850357,
+    "wof:lastmodified":1695886126,
     "wof:name":"Dolega",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/171/337/421171337.geojson
+++ b/data/421/171/337/421171337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07461,
-    "geom:area_square_m":911259100.663472,
+    "geom:area_square_m":911259100.663632,
     "geom:bbox":"-79.9898090706,8.77759841515,-79.706497192,9.19534032296",
     "geom:latitude":8.980324,
     "geom:longitude":-79.862918,
@@ -127,12 +127,13 @@
         "qs_pg:id":1263650,
         "wd:id":"Q2217021"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008890,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"54a25f6bfe693391d104cacca9530532",
+    "wof:geomhash":"17b7ce47a060ebb2443cd80d5a80eae8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421171337,
-    "wof:lastmodified":1582319482,
+    "wof:lastmodified":1695886697,
     "wof:name":"La Chorrera",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/171/339/421171339.geojson
+++ b/data/421/171/339/421171339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075269,
-    "geom:area_square_m":920684597.920507,
+    "geom:area_square_m":920684318.324647,
     "geom:bbox":"-82.564673,8.088555,-82.207541,8.763444",
     "geom:latitude":8.418525,
     "geom:longitude":-82.388611,
@@ -369,12 +369,13 @@
         "qs_pg:id":1263656,
         "wd:id":"Q2215578"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008890,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"38cffba283d842cb1a4bb2d615466b15",
+    "wof:geomhash":"4e8579df00f85f4fff6b3e1f78f803bd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -384,7 +385,7 @@
         }
     ],
     "wof:id":421171339,
-    "wof:lastmodified":1636495961,
+    "wof:lastmodified":1695886704,
     "wof:name":"David",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/171/341/421171341.geojson
+++ b/data/421/171/341/421171341.geojson
@@ -129,6 +129,7 @@
         "qs_pg:id":1263657,
         "wd:id":"Q1650967"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008890,
     "wof:geom_alt":[
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421171341,
-    "wof:lastmodified":1694492486,
+    "wof:lastmodified":1695886698,
     "wof:name":"Montijo",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/421/171/349/421171349.geojson
+++ b/data/421/171/349/421171349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124151,
-    "geom:area_square_m":1520728068.726718,
+    "geom:area_square_m":1520728150.24011,
     "geom:bbox":"-81.594193,7.609083,-81.16803,8.146676",
     "geom:latitude":7.860303,
     "geom:longitude":-81.344365,
@@ -111,12 +111,13 @@
         "qs_pg:id":1263671,
         "wd:id":"Q1651000"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008890,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5ba8fd134c9d9a811a61def799e79d74",
+    "wof:geomhash":"897851c0f9af072ac0644d53a349dff6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421171349,
-    "wof:lastmodified":1627522492,
+    "wof:lastmodified":1695886128,
     "wof:name":"Son\u00e1",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/421/171/351/421171351.geojson
+++ b/data/421/171/351/421171351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027947,
-    "geom:area_square_m":341748032.515245,
+    "geom:area_square_m":341747734.213451,
     "geom:bbox":"-80.115971,8.406437,-79.902293,8.652292",
     "geom:latitude":8.529212,
     "geom:longitude":-80.028045,
@@ -144,12 +144,13 @@
         "qs_pg:id":1242681,
         "wd:id":"Q2072542"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008890,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4f7590141de57653e0d5d7d232979aa2",
+    "wof:geomhash":"095ab74d8960b71e40e54221434e829d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":421171351,
-    "wof:lastmodified":1690850357,
+    "wof:lastmodified":1695886705,
     "wof:name":"San Carlos",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/172/507/421172507.geojson
+++ b/data/421/172/507/421172507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058604,
-    "geom:area_square_m":718215330.940804,
+    "geom:area_square_m":718215207.066288,
     "geom:bbox":"-80.508123,7.47089,-80.163113,7.838288",
     "geom:latitude":7.641549,
     "geom:longitude":-80.308119,
@@ -152,12 +152,13 @@
         "qs_pg:id":1313004,
         "wd:id":"Q2217049"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008945,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f029363ad444a34d7be8cd1edadc94f3",
+    "wof:geomhash":"440e1660a40be0b1ae5e71d723f4c1b8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421172507,
-    "wof:lastmodified":1636495958,
+    "wof:lastmodified":1695886704,
     "wof:name":"Las Tablas",
     "wof:parent_id":85675785,
     "wof:placetype":"county",

--- a/data/421/173/571/421173571.geojson
+++ b/data/421/173/571/421173571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036308,
-    "geom:area_square_m":444253787.197906,
+    "geom:area_square_m":444253175.513544,
     "geom:bbox":"-81.123687,8.179809,-80.817384,8.418748",
     "geom:latitude":8.299077,
     "geom:longitude":-81.005018,
@@ -135,12 +135,13 @@
         "qs_pg:id":510441,
         "wd:id":"Q2073037"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459008990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"579c4342bd32304029407f12a12f2797",
+    "wof:geomhash":"b7f39384b19595d6f9df95179d1003db",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421173571,
-    "wof:lastmodified":1636495957,
+    "wof:lastmodified":1695886704,
     "wof:name":"San Francisco",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/421/175/369/421175369.geojson
+++ b/data/421/175/369/421175369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02775,
-    "geom:area_square_m":339485760.684612,
+    "geom:area_square_m":339485536.19645,
     "geom:bbox":"-79.146164,8.205167,-78.808197,8.491611",
     "geom:latitude":8.360931,
     "geom:longitude":-78.948344,
@@ -203,12 +203,13 @@
         "qs_pg:id":368805,
         "wd:id":"Q2216400"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009065,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa454cc471ff4923c891b4cd229ad7ff",
+    "wof:geomhash":"07c687e3efe3f073d24d74e769d01362",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":421175369,
-    "wof:lastmodified":1690850334,
+    "wof:lastmodified":1695886704,
     "wof:name":"Balboa",
     "wof:parent_id":85675789,
     "wof:placetype":"county",

--- a/data/421/175/373/421175373.geojson
+++ b/data/421/175/373/421175373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04035,
-    "geom:area_square_m":493125430.851705,
+    "geom:area_square_m":493125395.519739,
     "geom:bbox":"-82.556128,8.594837,-82.260214,8.880654",
     "geom:latitude":8.750324,
     "geom:longitude":-82.414362,
@@ -133,12 +133,13 @@
         "qs_pg:id":368807,
         "wd:id":"Q893253"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009065,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b80c4cfd37f4e0e94c725780d719ac81",
+    "wof:geomhash":"a39ba12280d3d242d2112128f4aea90d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421175373,
-    "wof:lastmodified":1690850335,
+    "wof:lastmodified":1695886123,
     "wof:name":"Boquete",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/175/375/421175375.geojson
+++ b/data/421/175/375/421175375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00424,
-    "geom:area_square_m":51769345.036324,
+    "geom:area_square_m":51769265.307684,
     "geom:bbox":"-79.544892,9.027815,-79.437522,9.091365",
     "geom:latitude":9.06006,
     "geom:longitude":-79.489176,
@@ -152,12 +152,13 @@
         "qs_pg:id":368817,
         "wd:id":"Q932699"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009065,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"424cf5b6e9ee698bac3f8c8a0e78d4f9",
+    "wof:geomhash":"87532a895a66b60ef30e26f72e65c4af",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421175375,
-    "wof:lastmodified":1690850335,
+    "wof:lastmodified":1695886697,
     "wof:name":"San Miguelito",
     "wof:parent_id":85675789,
     "wof:placetype":"county",

--- a/data/421/176/107/421176107.geojson
+++ b/data/421/176/107/421176107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.435077,
-    "geom:area_square_m":5311853264.032524,
+    "geom:area_square_m":5311853028.153035,
     "geom:bbox":"-79.27791,8.808291,-78.062597,9.395422",
     "geom:latitude":9.116003,
     "geom:longitude":-78.6524,
@@ -120,12 +120,13 @@
         "qs_pg:id":1331296,
         "wd:id":"Q2215925"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009095,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"beac745d5b295eaba98fa94ca8c1e56f",
+    "wof:geomhash":"7e2fd4cdc2851d1c35ea4323822bc0c7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421176107,
-    "wof:lastmodified":1690850354,
+    "wof:lastmodified":1695886125,
     "wof:name":"Chepo",
     "wof:parent_id":85675789,
     "wof:placetype":"county",

--- a/data/421/176/641/421176641.geojson
+++ b/data/421/176/641/421176641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018458,
-    "geom:area_square_m":225868091.471012,
+    "geom:area_square_m":225868091.470998,
     "geom:bbox":"-81.9893978647,8.16060880232,-81.8286314496,8.34581633583",
     "geom:latitude":8.257536,
     "geom:longitude":-81.90191,
@@ -126,12 +126,13 @@
         "qs_pg:id":990179,
         "wd:id":"Q2217004"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009115,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5e322928e687717b4e7b82137354d79b",
+    "wof:geomhash":"b6cfdae1aeef2dedaebcd6c3d04999f0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421176641,
-    "wof:lastmodified":1582319482,
+    "wof:lastmodified":1695886698,
     "wof:name":"San F\u00e9lix",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/181/403/421181403.geojson
+++ b/data/421/181/403/421181403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158782,
-    "geom:area_square_m":1941040823.706646,
+    "geom:area_square_m":1941040808.8221,
     "geom:bbox":"-81.229882,8.387749,-80.729942,8.889305",
     "geom:latitude":8.64774,
     "geom:longitude":-80.994295,
@@ -132,12 +132,13 @@
         "qs_pg:id":510448,
         "wd:id":"Q3711449"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009295,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2b3728944437ae18917f3059d2ef1a9f",
+    "wof:geomhash":"e17e8c7e58e1175744e4493233f04842",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421181403,
-    "wof:lastmodified":1690850334,
+    "wof:lastmodified":1695886704,
     "wof:name":"Santa Fe",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/421/181/905/421181905.geojson
+++ b/data/421/181/905/421181905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079834,
-    "geom:area_square_m":975552899.13946,
+    "geom:area_square_m":975553051.266207,
     "geom:bbox":"-80.172155,8.630933,-79.743553,8.996314",
     "geom:latitude":8.797556,
     "geom:longitude":-79.992388,
@@ -120,12 +120,13 @@
         "qs_pg:id":510431,
         "wd:id":"Q2216086"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009312,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a2c466e3117f9c9a86501f947356ba8e",
+    "wof:geomhash":"9db4b34d2d9a6eb23bb47e5c1f759c1b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421181905,
-    "wof:lastmodified":1690850333,
+    "wof:lastmodified":1695886125,
     "wof:name":"Capira",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/184/905/421184905.geojson
+++ b/data/421/184/905/421184905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061663,
-    "geom:area_square_m":754044453.938112,
+    "geom:area_square_m":754044272.613384,
     "geom:bbox":"-82.17895,8.328543,-81.900332,8.767386",
     "geom:latitude":8.529946,
     "geom:longitude":-82.031914,
@@ -115,12 +115,13 @@
         "qs_pg:id":1014778,
         "wd:id":"Q3710719"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009426,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"270f12a4cd3d3db14ba34cdaa26e8610",
+    "wof:geomhash":"87400d2cca7b5c076cfa2ca00cb90385",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421184905,
-    "wof:lastmodified":1690850346,
+    "wof:lastmodified":1695886124,
     "wof:name":"Besiko",
     "wof:parent_id":85675807,
     "wof:placetype":"county",

--- a/data/421/189/053/421189053.geojson
+++ b/data/421/189/053/421189053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0308,
-    "geom:area_square_m":376542227.070704,
+    "geom:area_square_m":376542037.530469,
     "geom:bbox":"-80.071414,8.520674,-79.693275,8.703168",
     "geom:latitude":8.620919,
     "geom:longitude":-79.914201,
@@ -126,12 +126,13 @@
         "qs_pg:id":1110013,
         "wd:id":"Q431342"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009603,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d41b93fa1c0c8e7dae8c3001b325483",
+    "wof:geomhash":"7169af8fc0a1be808d7884b2f1931303",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421189053,
-    "wof:lastmodified":1690850330,
+    "wof:lastmodified":1695886125,
     "wof:name":"Chame",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/189/055/421189055.geojson
+++ b/data/421/189/055/421189055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007363,
-    "geom:area_square_m":90159068.785041,
+    "geom:area_square_m":90158773.819729,
     "geom:bbox":"-80.508111,7.923423,-80.391722,8.029135",
     "geom:latitude":7.97579,
     "geom:longitude":-80.448952,
@@ -118,12 +118,13 @@
         "qs_pg:id":1110014,
         "wd:id":"Q2216071"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009603,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9475c2c434382a15aa704ebb4a32cf74",
+    "wof:geomhash":"b12e298bf32971600883fc647abcabbc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421189055,
-    "wof:lastmodified":1690850330,
+    "wof:lastmodified":1695886126,
     "wof:name":"Chitr\u00e9",
     "wof:parent_id":85675781,
     "wof:placetype":"county",

--- a/data/421/189/057/421189057.geojson
+++ b/data/421/189/057/421189057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085133,
-    "geom:area_square_m":1040573428.263164,
+    "geom:area_square_m":1040573428.262971,
     "geom:bbox":"-80.7248815039,8.48741220135,-80.3820907946,8.93464438947",
     "geom:latitude":8.699894,
     "geom:longitude":-80.534995,
@@ -117,12 +117,13 @@
         "qs_pg:id":1110015,
         "wd:id":"Q2215435"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009603,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"43c6694cfaab79237805160f1b10177c",
+    "wof:geomhash":"ff8a6fe3b2da7ad9d5bb6e6228dee55f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421189057,
-    "wof:lastmodified":1582319480,
+    "wof:lastmodified":1695886697,
     "wof:name":"La Pintada",
     "wof:parent_id":85675771,
     "wof:placetype":"county",

--- a/data/421/191/757/421191757.geojson
+++ b/data/421/191/757/421191757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04891,
-    "geom:area_square_m":598309938.839926,
+    "geom:area_square_m":598309574.743032,
     "geom:bbox":"-80.828116,8.22325,-80.39325,8.583952",
     "geom:latitude":8.391756,
     "geom:longitude":-80.58498,
@@ -113,12 +113,13 @@
         "qs_pg:id":114260,
         "wd:id":"Q2215891"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009707,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6727cd87633d97f70eb0d537ec714709",
+    "wof:geomhash":"ac4d14aa1145101b58a4977d205b3e8f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421191757,
-    "wof:lastmodified":1627522491,
+    "wof:lastmodified":1695886127,
     "wof:name":"Nat\u00e1",
     "wof:parent_id":85675771,
     "wof:placetype":"county",

--- a/data/421/196/973/421196973.geojson
+++ b/data/421/196/973/421196973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.404261,
-    "geom:area_square_m":4946971740.7008,
+    "geom:area_square_m":4946972359.229254,
     "geom:bbox":"-78.157208,7.507522,-77.158488,9.099759",
     "geom:latitude":8.243325,
     "geom:longitude":-77.689673,
@@ -123,12 +123,13 @@
         "qs_pg:id":1263652,
         "wd:id":"Q2216562"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009899,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d5605b4acb52bf21daad3ac93b8ebad2",
+    "wof:geomhash":"ec2c94a9b35cb48a724cda60e008cd15",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421196973,
-    "wof:lastmodified":1690850338,
+    "wof:lastmodified":1695886128,
     "wof:name":"Pinogana",
     "wof:parent_id":85675795,
     "wof:placetype":"county",

--- a/data/421/196/975/421196975.geojson
+++ b/data/421/196/975/421196975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170695,
-    "geom:area_square_m":2083481362.517619,
+    "geom:area_square_m":2083481512.64053,
     "geom:bbox":"-79.69148,8.928972,-79.133238,9.498281",
     "geom:latitude":9.207578,
     "geom:longitude":-79.42155,
@@ -139,12 +139,13 @@
         "qs_pg:id":1263654,
         "wd:id":"Q2216411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459009899,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bdec3f90d30d1806dfc623e0004c38ee",
+    "wof:geomhash":"a1785f102dea8903a3a11d5a97890d32",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":421196975,
-    "wof:lastmodified":1690850338,
+    "wof:lastmodified":1695886127,
     "wof:name":"Panam\u00e1",
     "wof:parent_id":85675789,
     "wof:placetype":"county",

--- a/data/421/199/909/421199909.geojson
+++ b/data/421/199/909/421199909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079853,
-    "geom:area_square_m":977700376.349808,
+    "geom:area_square_m":977700009.19003,
     "geom:bbox":"-81.148463,7.728416,-80.694549,8.254216",
     "geom:latitude":8.036454,
     "geom:longitude":-80.967739,
@@ -148,12 +148,13 @@
         "qs_pg:id":510446,
         "wd:id":"Q3711454"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459010004,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b9601844cf56cfdcfd60ae2b41f1df40",
+    "wof:geomhash":"32c69101c8326b66d3abb514b73267f1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":421199909,
-    "wof:lastmodified":1690850342,
+    "wof:lastmodified":1695886704,
     "wof:name":"Santiago",
     "wof:parent_id":85675791,
     "wof:placetype":"county",

--- a/data/421/202/587/421202587.geojson
+++ b/data/421/202/587/421202587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030825,
-    "geom:area_square_m":377883084.268667,
+    "geom:area_square_m":377883039.98634,
     "geom:bbox":"-80.246187,7.410611,-79.99247,7.647361",
     "geom:latitude":7.508072,
     "geom:longitude":-80.106652,
@@ -125,12 +125,13 @@
         "qs_pg:id":224823,
         "wd:id":"Q2216610"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459010123,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d2a9cca2404a260b505bffecc31de5e5",
+    "wof:geomhash":"62f6196fd689339e3e6a6f6bffb212c2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421202587,
-    "wof:lastmodified":1690850320,
+    "wof:lastmodified":1695886127,
     "wof:name":"Pedas\u00ed",
     "wof:parent_id":85675785,
     "wof:placetype":"county",

--- a/data/421/202/589/421202589.geojson
+++ b/data/421/202/589/421202589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.141498,
-    "geom:area_square_m":1729662268.742975,
+    "geom:area_square_m":1729662612.129439,
     "geom:bbox":"-80.526121,8.300966,-80.110406,9.056336",
     "geom:latitude":8.667976,
     "geom:longitude":-80.308143,
@@ -128,12 +128,13 @@
         "qs_pg:id":224824,
         "wd:id":"Q2216569"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459010123,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ce0ba949b5398560fe8b1b71d246daa1",
+    "wof:geomhash":"9859d7d25a1ccf2e4f227888db221550",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421202589,
-    "wof:lastmodified":1690850320,
+    "wof:lastmodified":1695886697,
     "wof:name":"Penonom\u00e9",
     "wof:parent_id":85675771,
     "wof:placetype":"county",

--- a/data/421/202/705/421202705.geojson
+++ b/data/421/202/705/421202705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03722,
-    "geom:area_square_m":455313754.858999,
+    "geom:area_square_m":455314087.083283,
     "geom:bbox":"-82.795136,8.277361,-82.451637,8.463654",
     "geom:latitude":8.381877,
     "geom:longitude":-82.623549,
@@ -119,12 +119,13 @@
         "qs_pg:id":226345,
         "wd:id":"Q8193110"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459010127,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a778ddb45958572792fa9a75b7f6e236",
+    "wof:geomhash":"9bdb9b47a3f811c2d098eca98d845a4c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421202705,
-    "wof:lastmodified":1690850320,
+    "wof:lastmodified":1695886124,
     "wof:name":"Alanje",
     "wof:parent_id":85675767,
     "wof:placetype":"county",

--- a/data/421/203/467/421203467.geojson
+++ b/data/421/203/467/421203467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035058,
-    "geom:area_square_m":428180256.719359,
+    "geom:area_square_m":428179953.346072,
     "geom:bbox":"-79.79705,8.863305,-79.560753,9.122946",
     "geom:latitude":8.988116,
     "geom:longitude":-79.684514,
@@ -125,12 +125,13 @@
         "qs_pg:id":231696,
         "wd:id":"Q2216621"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459010153,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"53a4c24c09eaf1b4b4e4847aefeea83d",
+    "wof:geomhash":"916a64e044cdc22b17c3407845f2d292",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421203467,
-    "wof:lastmodified":1690850319,
+    "wof:lastmodified":1695886124,
     "wof:name":"Arraijan",
     "wof:parent_id":1108805611,
     "wof:placetype":"county",

--- a/data/421/203/469/421203469.geojson
+++ b/data/421/203/469/421203469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105439,
-    "geom:area_square_m":1292869007.65511,
+    "geom:area_square_m":1292869133.874597,
     "geom:bbox":"-80.729363,7.229583,-80.210741,7.563144",
     "geom:latitude":7.413705,
     "geom:longitude":-80.505766,
@@ -114,12 +114,13 @@
         "qs_pg:id":231697,
         "wd:id":"Q2216393"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PA",
     "wof:created":1459010153,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"83f4f51b1673b33c64830640cafa2b7e",
+    "wof:geomhash":"820622747a1f0778b0b63cf2a10cffd7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421203469,
-    "wof:lastmodified":1627522493,
+    "wof:lastmodified":1695886129,
     "wof:name":"Tonos\u00ed",
     "wof:parent_id":85675785,
     "wof:placetype":"county",

--- a/data/856/321/79/85632179.geojson
+++ b/data/856/321/79/85632179.geojson
@@ -1103,6 +1103,7 @@
         "hasc:id":"PA",
         "icao:code":"HP",
         "ioc:id":"PAN",
+        "iso:code":"PA",
         "itu:id":"PNR",
         "loc:id":"n79068688",
         "m49:code":"591",
@@ -1117,6 +1118,7 @@
         "wk:page":"Panama",
         "wmo:id":"PM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:country_alpha3":"PAN",
     "wof:geom_alt":[
@@ -1138,7 +1140,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694639513,
+    "wof:lastmodified":1695881168,
     "wof:name":"Panama",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/757/67/85675767.geojson
+++ b/data/856/757/67/85675767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.542955,
-    "geom:area_square_m":6640186132.401863,
+    "geom:area_square_m":6640185287.614379,
     "geom:bbox":"-83.052241,8.007501,-81.512902,8.921354",
     "geom:latitude":8.487159,
     "geom:longitude":-82.402449,
@@ -312,17 +312,19 @@
         "gn:id":3712410,
         "gp:id":2346552,
         "hasc:id":"PA.CH",
+        "iso:code":"PA-4",
         "iso:id":"PA-4",
         "qs_pg:id":1222799,
         "unlc:id":"PA-4",
         "wd:id":"Q739651",
         "wk:page":"Chiriqu\u00ed Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6a71e2f9d856cef15cfc2f9cac3df5c7",
+    "wof:geomhash":"cc38b8091e8753bbeb0d5e9944e6da98",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690850298,
+    "wof:lastmodified":1695884352,
     "wof:name":"Chiriqu\u00ed",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/71/85675771.geojson
+++ b/data/856/757/71/85675771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.405745,
-    "geom:area_square_m":4961319427.79191,
+    "geom:area_square_m":4961319372.970658,
     "geom:bbox":"-80.828116,8.093201,-80.045615,9.056336",
     "geom:latitude":8.550989,
     "geom:longitude":-80.42957,
@@ -306,17 +306,19 @@
         "gn:id":3712162,
         "gp:id":2346553,
         "hasc:id":"PA.CC",
+        "iso:code":"PA-2",
         "iso:id":"PA-2",
         "qs_pg:id":318544,
         "unlc:id":"PA-2",
         "wd:id":"Q825799",
         "wk:page":"Cocl\u00e9 Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"27cefe55472bb438030741d24873cc6e",
+    "wof:geomhash":"0c811c21c174084ce1d48b26752e11ab",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690850299,
+    "wof:lastmodified":1695884352,
     "wof:name":"Cocl\u00e9",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/75/85675775.geojson
+++ b/data/856/757/75/85675775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.401956,
-    "geom:area_square_m":4906488851.656958,
+    "geom:area_square_m":4906490562.499024,
     "geom:bbox":"-80.873091,8.624301,-79.072297,9.634694",
     "geom:latitude":9.185669,
     "geom:longitude":-80.017502,
@@ -318,17 +318,19 @@
         "gn:id":3712073,
         "gp:id":2346554,
         "hasc:id":"PA.CL",
+        "iso:code":"PA-3",
         "iso:id":"PA-3",
         "qs_pg:id":1168713,
         "unlc:id":"PA-3",
         "wd:id":"Q820514",
         "wk:page":"Col\u00f3n Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fd2326fb1ef8954fd659622235c15281",
+    "wof:geomhash":"ef8aaca719739a0eac1e9a22690d643a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690850298,
+    "wof:lastmodified":1695884352,
     "wof:name":"Col\u00f3n",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/81/85675781.geojson
+++ b/data/856/757/81/85675781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.194787,
-    "geom:area_square_m":2385855135.509861,
+    "geom:area_square_m":2385855118.145341,
     "geom:bbox":"-80.95604,7.538934,-80.391722,8.144549",
     "geom:latitude":7.874893,
     "geom:longitude":-80.70536,
@@ -296,17 +296,19 @@
         "gn:id":3708710,
         "gp:id":2346556,
         "hasc:id":"PA.HE",
+        "iso:code":"PA-6",
         "iso:id":"PA-6",
         "qs_pg:id":894955,
         "unlc:id":"PA-6",
         "wd:id":"Q842886",
         "wk:page":"Herrera Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de2cc34d2ac09de578f3e00346fde983",
+    "wof:geomhash":"179ca2fee0d7627e70fe837df6d859bf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690850299,
+    "wof:lastmodified":1695884834,
     "wof:name":"Herrera",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/85/85675785.geojson
+++ b/data/856/757/85/85675785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.312035,
-    "geom:area_square_m":3824580956.994836,
+    "geom:area_square_m":3824581393.242945,
     "geom:bbox":"-80.729363,7.229583,-79.99247,8.005972",
     "geom:latitude":7.586402,
     "geom:longitude":-80.39155,
@@ -296,17 +296,19 @@
         "gn:id":3704961,
         "gp:id":2346557,
         "hasc:id":"PA.LS",
+        "iso:code":"PA-7",
         "iso:id":"PA-7",
         "qs_pg:id":894956,
         "unlc:id":"PA-7",
         "wd:id":"Q911278",
         "wk:page":"Los Santos Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3dda26e3f4f75ab1325d2287a7a2fbab",
+    "wof:geomhash":"dfe75392bfd705355c19e07c72e2ac90",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690850299,
+    "wof:lastmodified":1695884835,
     "wof:name":"Los Santos",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/89/85675789.geojson
+++ b/data/856/757/89/85675789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.72177,
-    "geom:area_square_m":8813200697.480808,
+    "geom:area_square_m":8813200925.368832,
     "geom:bbox":"-79.69148,8.205167,-78.062597,9.498281",
     "geom:latitude":9.06861,
     "geom:longitude":-78.850315,
@@ -289,17 +289,19 @@
         "gn:id":3703433,
         "gp:id":2346558,
         "hasc:id":"PA.PM",
+        "iso:code":"PA-8",
         "iso:id":"PA-8",
         "qs_pg:id":1168711,
         "unlc:id":"PA-8",
         "wd:id":"Q557506",
         "wk:page":"Panam\u00e1 Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1bbc58ccd746e7ee44af1467d4edfb3a",
+    "wof:geomhash":"cb0ca751162e468c6af7467e3dce7acd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -314,7 +316,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690850298,
+    "wof:lastmodified":1695884834,
     "wof:name":"Panama",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/91/85675791.geojson
+++ b/data/856/757/91/85675791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.875748,
-    "geom:area_square_m":10721053327.542027,
+    "geom:area_square_m":10721052438.437355,
     "geom:bbox":"-81.894112,7.20475,-80.611426,8.889305",
     "geom:latitude":8.078899,
     "geom:longitude":-81.135637,
@@ -311,17 +311,19 @@
         "gn:id":3700159,
         "gp:id":2346560,
         "hasc:id":"PA.VR",
+        "iso:code":"PA-9",
         "iso:id":"PA-9",
         "qs_pg:id":219593,
         "unlc:id":"PA-9",
         "wd:id":"Q593137",
         "wk:page":"Veraguas Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"09e2a9c97045f00c11c7f72acff57b6f",
+    "wof:geomhash":"05b7cbea9b7ccc29614b768d1c746953",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690850299,
+    "wof:lastmodified":1695884835,
     "wof:name":"Veraguas",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/757/95/85675795.geojson
+++ b/data/856/757/95/85675795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.003122,
-    "geom:area_square_m":12277613504.306852,
+    "geom:area_square_m":12277614928.224072,
     "geom:bbox":"-78.508152,7.225743,-77.158488,9.099759",
     "geom:latitude":8.167728,
     "geom:longitude":-77.919659,
@@ -303,17 +303,19 @@
         "gn:id":3711671,
         "gp:id":2346555,
         "hasc:id":"PA.DA",
+        "iso:code":"PA-5",
         "iso:id":"PA-5",
         "qs_pg:id":318545,
         "unlc:id":"PA-5",
         "wd:id":"Q688660",
         "wk:page":"Dari\u00e9n Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3a473a642405abbc5e23b3596ed891c2",
+    "wof:geomhash":"ebe8e222bd8f935d6fbc9db6d50de803",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690850297,
+    "wof:lastmodified":1695884351,
     "wof:name":"Dari\u00e9n",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/758/01/85675801.geojson
+++ b/data/856/758/01/85675801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.186971,
-    "geom:area_square_m":2282517394.403632,
+    "geom:area_square_m":2282517394.404227,
     "geom:bbox":"-79.278296,8.520338,-77.357987,9.564917",
     "geom:latitude":9.145604,
     "geom:longitude":-78.270912,
@@ -323,12 +323,14 @@
         "gn:id":3701537,
         "gp:id":2346559,
         "hasc:id":"PA.SB",
+        "iso:code":"PA-KY",
         "iso:id":"PA-KY",
         "qs_pg:id":423870,
         "unlc:id":"PA-KY",
         "wd:id":"Q919017",
         "wk:page":"Guna Yala"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108693213
     ],
@@ -336,7 +338,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ad5290256dd9ec218f7b8dab68b48a87",
+    "wof:geomhash":"3bb5d7e83bf4293797b3a3b7842df226",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -351,7 +353,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690850297,
+    "wof:lastmodified":1695884834,
     "wof:name":"Kuna Yala",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/758/05/85675805.geojson
+++ b/data/856/758/05/85675805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.384606,
-    "geom:area_square_m":4694296216.52823,
+    "geom:area_square_m":4694296291.547486,
     "geom:bbox":"-82.936112,8.811255,-82.008163,9.618956",
     "geom:latitude":9.217239,
     "geom:longitude":-82.582335,
@@ -306,6 +306,7 @@
         "gn:id":3713954,
         "gp:id":2346551,
         "hasc:id":"PA.BC",
+        "iso:code":"PA-1",
         "iso:id":"PA-1",
         "nyt:id":"N6546044179490659521",
         "qs_pg:id":423869,
@@ -313,11 +314,12 @@
         "wd:id":"Q217138",
         "wk:page":"Bocas del Toro Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"094fe97c3b65082680aac7fa711bfa84",
+    "wof:geomhash":"33c0a268125c25ffa64cfa5c1293c536",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -332,7 +334,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690850296,
+    "wof:lastmodified":1695884351,
     "wof:name":"Bocas del Toro",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/758/07/85675807.geojson
+++ b/data/856/758/07/85675807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.558721,
-    "geom:area_square_m":6829908436.640213,
+    "geom:area_square_m":6829908436.640495,
     "geom:bbox":"-82.4207813104,8.14153325444,-81.1431707785,9.188249588",
     "geom:latitude":8.659151,
     "geom:longitude":-81.767462,
@@ -274,17 +274,19 @@
         "gn:id":7303688,
         "gp:id":28358287,
         "hasc:id":"PA.NB",
+        "iso:code":"PA-NB",
         "iso:id":"PA-NB",
         "qs_pg:id":64640,
         "unlc:id":"PA-NB",
         "wd:id":"Q1129783",
         "wk:page":"Ng\u00e4be-Bugl\u00e9 Comarca"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"71dbc480d2146764598923e26dea529f",
+    "wof:geomhash":"229f2bd3fbd2048d778e837a31add54d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -299,7 +301,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1582319470,
+    "wof:lastmodified":1695884352,
     "wof:name":"Ng\u00f6be Bugl\u00e9",
     "wof:parent_id":85632179,
     "wof:placetype":"region",

--- a/data/856/758/11/85675811.geojson
+++ b/data/856/758/11/85675811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.340926,
-    "geom:area_square_m":4171907452.089035,
+    "geom:area_square_m":4171907452.08926,
     "geom:bbox":"-78.3134856108,7.59604880549,-77.284593,8.79133178747",
     "geom:latitude":8.251863,
     "geom:longitude":-77.760286,
@@ -281,17 +281,19 @@
         "gn:id":7303686,
         "gp:id":28358286,
         "hasc:id":"PA.EM",
+        "iso:code":"PA-EM",
         "iso:id":"PA-EM",
         "qs_pg:id":64643,
         "unlc:id":"PA-EM",
         "wd:id":"Q1141041",
         "wk:page":"Comarca Ember\u00e1-Wounaan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ef0f96befe758ff837759a8b6e50c8e9",
+    "wof:geomhash":"1bc3912522484f167ffe64fe94556dae",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1582319470,
+    "wof:lastmodified":1695884352,
     "wof:name":"Ember\u00e1",
     "wof:parent_id":85632179,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.